### PR TITLE
Fix clippy warnings in package

### DIFF
--- a/src/autocomplete/context.rs
+++ b/src/autocomplete/context.rs
@@ -269,12 +269,12 @@ fn analyze_context(before_cursor: &str) -> (SuggestionContext, String) {
     let partial: String = chars[start..i].iter().collect();
 
     // Check if the partial starts with a dot (field access)
-    if partial.starts_with('.') {
+    if let Some(stripped) = partial.strip_prefix('.') {
         // Field context - return the part after the LAST dot (for nested fields like .user.na)
         let field_partial = if let Some(last_dot_pos) = partial.rfind('.') {
             partial[last_dot_pos + 1..].to_string()
         } else {
-            partial[1..].to_string()
+            stripped.to_string()
         };
         return (SuggestionContext::FieldContext, field_partial);
     }

--- a/src/autocomplete/json_analyzer.rs
+++ b/src/autocomplete/json_analyzer.rs
@@ -67,7 +67,7 @@ impl JsonAnalyzer {
         };
 
         // Extract fields from the value at this path
-        self.extract_fields_from_value(value_at_path, prefix)
+        extract_fields_from_value(value_at_path, prefix)
     }
 
     /// Get top-level fields only
@@ -153,39 +153,39 @@ impl JsonAnalyzer {
         Some(current)
     }
 
-    /// Extract fields from a specific JSON value
-    fn extract_fields_from_value(&self, value: &Value, prefix: &str) -> Vec<Suggestion> {
-        match value {
-            Value::Object(map) => {
-                let mut fields: Vec<_> = map
-                    .keys()
-                    .filter(|k| {
-                        prefix.is_empty()
-                            || k.to_lowercase().starts_with(&prefix.to_lowercase())
-                    })
-                    .map(|k| Suggestion::new(format!(".{}", k), SuggestionType::Field))
-                    .collect();
-                fields.sort_by(|a, b| a.text.cmp(&b.text));
-                fields
-            }
-            Value::Array(arr) => {
-                // For arrays, analyze the first element to get available fields
-                if let Some(first) = arr.first() {
-                    self.extract_fields_from_value(first, prefix)
-                } else {
-                    Vec::new()
-                }
-            }
-            _ => Vec::new(), // Primitives have no fields
-        }
-    }
-
     /// Get all field names (used in tests)
     #[cfg(test)]
     pub fn get_all_fields(&self) -> Vec<String> {
         let mut fields: Vec<_> = self.field_names.iter().cloned().collect();
         fields.sort();
         fields
+    }
+}
+
+/// Extract fields from a specific JSON value
+fn extract_fields_from_value(value: &Value, prefix: &str) -> Vec<Suggestion> {
+    match value {
+        Value::Object(map) => {
+            let mut fields: Vec<_> = map
+                .keys()
+                .filter(|k| {
+                    prefix.is_empty()
+                        || k.to_lowercase().starts_with(&prefix.to_lowercase())
+                })
+                .map(|k| Suggestion::new(format!(".{}", k), SuggestionType::Field))
+                .collect();
+            fields.sort_by(|a, b| a.text.cmp(&b.text));
+            fields
+        }
+        Value::Array(arr) => {
+            // For arrays, analyze the first element to get available fields
+            if let Some(first) = arr.first() {
+                extract_fields_from_value(first, prefix)
+            } else {
+                Vec::new()
+            }
+        }
+        _ => Vec::new(), // Primitives have no fields
     }
 }
 

--- a/src/editor/mode.rs
+++ b/src/editor/mode.rs
@@ -1,18 +1,13 @@
 /// VIM editing modes for the input field
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum EditorMode {
     /// Insert mode - typing inserts characters
+    #[default]
     Insert,
     /// Normal mode - VIM navigation and commands
     Normal,
     /// Operator mode - waiting for motion after operator (d or c)
     Operator(char),
-}
-
-impl Default for EditorMode {
-    fn default() -> Self {
-        EditorMode::Insert
-    }
 }
 
 impl EditorMode {


### PR DESCRIPTION
Fixed 3 clippy warnings identified in the codebase:

1. manual_strip (src/autocomplete/context.rs:277)
   - Changed manual string prefix stripping using partial[1..] to use strip_prefix('.') method for cleaner and more idiomatic code

2. only_used_in_recursion (src/autocomplete/json_analyzer.rs:157)
   - Converted extract_fields_from_value from a method to a standalone function since &self was only used for recursive calls, not for accessing instance state

3. derivable_impls (src/editor/mode.rs:12)
   - Replaced manual Default trait implementation with #[derive(Default)] and #[default] attribute on the Insert variant

All 161 tests continue to pass after these changes.