### PR TITLE
Exclude insert mode from global key q to allow inputs like "unique" filter

### DIFF
--- a/src/app/events.rs
+++ b/src/app/events.rs
@@ -65,8 +65,8 @@ impl App {
             return true;
         }
 
-        // q: Exit application
-        if key.code == KeyCode::Char('q') {
+        // q: Exit application (not in insert mode)
+        if key.code == KeyCode::Char('q') && self.editor_mode != EditorMode::Insert {
             self.should_quit = true;
             return true;
         }


### PR DESCRIPTION
I noticed, that if you are in insert mode, and want to use a filter like "unique", jiq is closed.

This does not seem like expected behaviour. Even though it is possible to auto-complete via tab, especially for the `unique` function, you should be able to type q in insert mode.

This pr fixes this.