### PR TITLE
fix: Prevent 'q' from quitting in insert mode

### DIFF
--- a/src/app/events.rs
+++ b/src/app/events.rs
@@ -1443,12 +1443,25 @@ mod tests {
     }
 
     #[test]
-    fn test_q_sets_quit_flag() {
+    fn test_q_sets_quit_flag_in_normal_mode() {
         let mut app = app_with_query(".");
+        app.editor_mode = EditorMode::Normal;
 
         app.handle_key_event(key(KeyCode::Char('q')));
 
         assert!(app.should_quit);
+    }
+
+    #[test]
+    fn test_q_does_not_quit_in_insert_mode() {
+        let mut app = app_with_query(".");
+        app.editor_mode = EditorMode::Insert;
+
+        app.handle_key_event(key(KeyCode::Char('q')));
+
+        // Should NOT quit - 'q' should be typed instead
+        assert!(!app.should_quit);
+        assert_eq!(app.query(), ".q");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Prevents pressing 'q' from quitting the application when in Insert mode
- Allows users to type queries containing 'q' (e.g., `unique`, `eq`, etc.)

Based on PR #11 by @dithmer with the following additions:
- Rebased onto latest main (resolving conflict with Ctrl+Q feature)
- Fixed failing test `test_q_sets_quit_flag`
- Added new test `test_q_does_not_quit_in_insert_mode`

## Test plan
- [x] All 243 tests pass
- [x] Clean release build succeeds
- [x] Manual testing: verify 'q' types in insert mode, quits in normal mode

Closes #11