### PR TITLE
feat(vim): Add ^ keybind to move to start of line

### DIFF
--- a/src/app/events/vim.rs
+++ b/src/app/events/vim.rs
@@ -52,8 +52,8 @@ pub fn handle_normal_mode_key(app: &mut App, key: KeyEvent) {
             app.input.textarea.move_cursor(CursorMove::Forward);
         }
 
-        // Line extent movement (0/$)
-        KeyCode::Char('0') | KeyCode::Home => {
+        // Line extent movement (0/^/$)
+        KeyCode::Char('0') | KeyCode::Char('^') | KeyCode::Home => {
             app.input.textarea.move_cursor(CursorMove::Head);
         }
         KeyCode::Char('$') | KeyCode::End => {
@@ -187,7 +187,7 @@ pub fn handle_operator_mode_key(app: &mut App, key: KeyEvent) {
         }
 
         // Line extent motions
-        KeyCode::Char('0') | KeyCode::Home => {
+        KeyCode::Char('0') | KeyCode::Char('^') | KeyCode::Home => {
             app.input.textarea.move_cursor(CursorMove::Head);
             true
         }
@@ -367,6 +367,19 @@ mod tests {
 
         app.handle_key_event(key(KeyCode::Char('d')));
         app.handle_key_event(key(KeyCode::Char('0')));
+
+        assert!(app.query().ends_with("first"));
+    }
+
+    #[test]
+    fn test_operator_d_caret_deletes_to_start_of_line() {
+        let mut app = app_with_query(".name.first");
+        // Move to middle of text
+        move_cursor_to_position(&mut app, 6);
+        app.input.editor_mode = EditorMode::Normal;
+
+        app.handle_key_event(key(KeyCode::Char('d')));
+        app.handle_key_event(key(KeyCode::Char('^')));
 
         assert!(app.query().ends_with("first"));
     }
@@ -665,6 +678,17 @@ mod tests {
         app.input.editor_mode = EditorMode::Normal;
 
         app.handle_key_event(key(KeyCode::Char('0')));
+
+        assert_eq!(app.input.textarea.cursor().1, 0);
+    }
+
+    #[test]
+    fn test_caret_moves_to_line_start() {
+        let mut app = app_with_query(".name");
+        app.input.textarea.move_cursor(CursorMove::End);
+        app.input.editor_mode = EditorMode::Normal;
+
+        app.handle_key_event(key(KeyCode::Char('^')));
 
         assert_eq!(app.input.textarea.cursor().1, 0);
     }

--- a/src/app/help_content.rs
+++ b/src/app/help_content.rs
@@ -22,7 +22,7 @@ pub const HELP_ENTRIES: &[(&str, &str)] = &[
     ("", "── INPUT: NORMAL MODE ──"),
     ("i/a/I/A", "Enter Insert mode"),
     ("h/l", "Move cursor left/right"),
-    ("0/$", "Jump to start/end of line"),
+    ("0/^/$", "Jump to start/end of line"),
     ("w/b/e", "Word navigation"),
     ("x/X", "Delete character"),
     ("dd/D", "Delete line/to end"),


### PR DESCRIPTION
Add support for ^ key in Normal mode and Operator mode to move cursor to the start of line, matching behavior of 0 key. Includes tests for both normal navigation and operator mode (d^).