### PR TITLE
chore: Remove unnecessary requirement reference comments

### DIFF
--- a/src/app/app_events/global.rs
+++ b/src/app/app_events/global.rs
@@ -176,13 +176,11 @@ pub fn handle_global_keys(app: &mut App, key: KeyEvent) -> bool {
         }
         KeyCode::Enter => {
             // Accept autocomplete suggestion if visible (same behavior as Tab)
-            // Requirements: 1.1, 1.2, 1.3, 1.4, 3.1
             if accept_autocomplete_suggestion(app) {
                 return true;
             }
 
             // Fall through to existing exit behavior when autocomplete not visible
-            // Requirements: 2.1, 2.2, 2.3
             // Execute any pending debounced query immediately (bypass debounce)
             if app.debouncer.has_pending() {
                 crate::editor::editor_events::execute_query(app);
@@ -1427,7 +1425,6 @@ mod tests {
     #[test]
     fn test_enter_accepts_suggestion_when_autocomplete_visible() {
         // Test Enter accepts suggestion when autocomplete visible
-        // Requirements: 1.1
         let mut app = app_with_query(".na");
         app.input.editor_mode = EditorMode::Insert;
         app.focus = Focus::InputField;
@@ -1450,7 +1447,6 @@ mod tests {
     #[test]
     fn test_enter_closes_autocomplete_popup_after_selection() {
         // Test Enter closes autocomplete popup after selection
-        // Requirements: 1.2
         let mut app = app_with_query(".na");
         app.input.editor_mode = EditorMode::Insert;
         app.focus = Focus::InputField;
@@ -1471,7 +1467,6 @@ mod tests {
     #[test]
     fn test_enter_exits_application_when_autocomplete_not_visible() {
         // Test Enter exits application when autocomplete not visible
-        // Requirements: 2.1
         let mut app = app_with_query(".");
         app.input.editor_mode = EditorMode::Insert;
         app.focus = Focus::InputField;
@@ -1489,7 +1484,6 @@ mod tests {
     #[test]
     fn test_enter_with_shift_modifier_bypasses_autocomplete_check() {
         // Test Enter with Shift modifier bypasses autocomplete check
-        // Requirements: 2.2
         let mut app = app_with_query(".na");
         app.input.editor_mode = EditorMode::Insert;
         app.focus = Focus::InputField;
@@ -1512,7 +1506,6 @@ mod tests {
     #[test]
     fn test_enter_with_alt_modifier_bypasses_autocomplete_check() {
         // Test Enter with Alt modifier bypasses autocomplete check
-        // Requirements: 2.3
         let mut app = app_with_query(".na");
         app.input.editor_mode = EditorMode::Insert;
         app.focus = Focus::InputField;

--- a/src/autocomplete/context.rs
+++ b/src/autocomplete/context.rs
@@ -599,12 +599,10 @@ mod tests {
     // ========== Regression Tests for Existing Behavior ==========
     // These tests verify that the ObjectKeyContext feature doesn't break
     // existing FieldContext and FunctionContext behavior.
-    // Requirements: 4.1, 4.2, 4.3, 4.4, 4.5
 
     #[test]
     fn test_regression_field_context_at_start() {
         // `.na` at start should return FieldContext (not ObjectKeyContext)
-        // Validates: Requirement 4.1
         let query = ".na";
         let tracker = tracker_for(query);
         let (ctx, partial) = analyze_context(query, &tracker);
@@ -616,7 +614,6 @@ mod tests {
     #[test]
     fn test_regression_field_context_after_pipe() {
         // `.services | .na` should return FieldContext
-        // Validates: Requirement 4.2
         let query = ".services | .na";
         let tracker = tracker_for(query);
         let (ctx, partial) = analyze_context(query, &tracker);
@@ -628,7 +625,6 @@ mod tests {
     #[test]
     fn test_regression_field_context_in_map() {
         // `map(.na` should return FieldContext
-        // Validates: Requirement 4.3
         let query = "map(.na";
         let tracker = tracker_for(query);
         let (ctx, partial) = analyze_context(query, &tracker);
@@ -640,7 +636,6 @@ mod tests {
     #[test]
     fn test_regression_function_context_at_start() {
         // `sel` at start should return FunctionContext
-        // Validates: Requirement 4.4
         let query = "sel";
         let tracker = tracker_for(query);
         let (ctx, partial) = analyze_context(query, &tracker);
@@ -652,7 +647,6 @@ mod tests {
     #[test]
     fn test_regression_function_context_after_pipe() {
         // `.services | sel` should return FunctionContext
-        // Validates: Requirement 4.5
         let query = ".services | sel";
         let tracker = tracker_for(query);
         let (ctx, partial) = analyze_context(query, &tracker);

--- a/src/clipboard/clipboard_events.rs
+++ b/src/clipboard/clipboard_events.rs
@@ -198,7 +198,6 @@ mod tests {
     // Feature: clipboard, Property 2: ANSI stripping preserves non-ANSI content
     // *For any* input text without ANSI escape sequences, stripping ANSI codes
     // should return the identical text.
-    // Validates: Requirements 2.4
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(100))]
 
@@ -218,7 +217,6 @@ mod tests {
     // Feature: clipboard, Property 3: ANSI stripping removes all escape sequences
     // *For any* input text with ANSI escape sequences, the stripped output should
     // contain no escape sequences (no `\x1b` characters).
-    // Validates: Requirements 2.4
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(100))]
 
@@ -260,7 +258,6 @@ mod tests {
 
     // Feature: clipboard, Property 5: Empty content rejection
     // *For any* empty string input, the copy operation should not proceed and return false.
-    // Validates: Requirements 1.4, 2.5
     //
     // This property is tested via unit tests since copy_query/copy_result require
     // a full App instance. The core property is that empty strings are rejected.

--- a/src/clipboard/osc52.rs
+++ b/src/clipboard/osc52.rs
@@ -47,7 +47,6 @@ mod tests {
     // Feature: clipboard, Property 1: OSC 52 encoding round-trip
     // *For any* input text string, encoding it with OSC 52 format and then
     // decoding the base64 portion should produce the original text.
-    // Validates: Requirements 3.2
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(100))]
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,7 +89,6 @@ mod tests {
     // Feature: config-system, Property 3: Invalid backend fallback
     // For any invalid clipboard backend value in a TOML config file, the config system
     // should log a warning and use the default clipboard backend value ("auto").
-    // Validates: Requirements 3.1, 3.2
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(100))]
 
@@ -124,7 +123,6 @@ backend = "{}"
     // Feature: config-system, Property 4: Malformed TOML fallback
     // For any malformed TOML syntax in the config file, the config system should
     // log an error with details and return a config with all default values.
-    // Validates: Requirements 3.3, 3.4
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(100))]
 
@@ -158,7 +156,6 @@ backend = "{}"
     // Feature: config-system, Property 5: Config path consistency
     // For any execution of the config loading function, it should attempt to load
     // from the same standardized path (~/.config/jiq/config.toml).
-    // Validates: Requirements 1.1
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(100))]
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -61,7 +61,6 @@ mod tests {
     // Feature: config-system, Property 1: Valid backend parsing
     // For any valid clipboard backend value ("auto", "system", or "osc52") in a TOML config file,
     // parsing the config should successfully extract and store that backend preference without errors.
-    // Validates: Requirements 1.2
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(100))]
 
@@ -94,7 +93,6 @@ backend = "{}"
     // Feature: config-system, Property 2: Missing fields use defaults
     // For any TOML config file with missing optional fields, parsing the config should
     // successfully complete and use default values for all missing fields.
-    // Validates: Requirements 2.3
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(100))]
 

--- a/src/notification/notification_state.rs
+++ b/src/notification/notification_state.rs
@@ -287,7 +287,6 @@ mod tests {
         #![proptest_config(ProptestConfig::with_cases(100))]
 
         /// Feature: clipboard, Property 4: Notification replacement
-        /// Validates: Requirements 4.4
         ///
         /// For any sequence of notification messages, only the most recent
         /// notification should be visible.


### PR DESCRIPTION
## Summary
- Removed unnecessary requirement reference comments that were part of implementation but don't add value when reading code
- Cleaned up 23 comments across 7 files:
  - 8 `// Requirements: X.X` style comments
  - 15 `// Validates: Requirement X.X` style comments

## Files Modified
- src/autocomplete/context.rs
- src/app/app_events/global.rs
- src/config.rs
- src/config/types.rs
- src/clipboard/clipboard_events.rs
- src/clipboard/osc52.rs
- src/notification/notification_state.rs

## Test Plan
- [x] All 852 tests pass
- [x] No functional changes - purely comment removal