### PR TITLE
fix: remove redundant serde_json import in async_openai.rs

### DIFF
--- a/src/ai/provider/async_openai.rs
+++ b/src/ai/provider/async_openai.rs
@@ -8,7 +8,6 @@ use std::sync::mpsc::Sender;
 use futures::StreamExt;
 use reqwest::Client;
 use serde::Serialize;
-use serde_json;
 use tokio_util::sync::CancellationToken;
 
 use super::AiError;


### PR DESCRIPTION
Removed single-component path import of serde_json that was flagged
by clippy. The code uses the fully qualified path serde_json::to_string,
so the explicit import is unnecessary.

Fixes clippy warning: clippy::single_component_path_imports