### PR TITLE
feat(autocomplete): suppress .[]. prefix inside element-context functions

### DIFF
--- a/src/autocomplete/brace_tracker.rs
+++ b/src/autocomplete/brace_tracker.rs
@@ -1,3 +1,4 @@
+use super::jq_functions::{JQ_FUNCTION_METADATA, is_element_context_function};
 use super::scan_state::ScanState;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -7,9 +8,27 @@ pub enum BraceType {
     Paren,
 }
 
+/// Context for parentheses that changes how autocomplete behaves
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FunctionContext {
+    /// Function that iterates over elements (map, select, sort_by, etc.)
+    /// Inner value is the function name for debugging/display.
+    ElementIterator(&'static str),
+    // TODO: Add WithEntries variant to suggest .key and .value fields
+    // inside with_entries() expressions
+}
+
+/// Information about an open brace/bracket/paren
+#[derive(Debug, Clone)]
+pub struct BraceInfo {
+    pub pos: usize,
+    pub brace_type: BraceType,
+    pub context: Option<FunctionContext>,
+}
+
 #[derive(Debug, Clone)]
 pub struct BraceTracker {
-    open_braces: Vec<(usize, BraceType)>,
+    open_braces: Vec<BraceInfo>,
     query_snapshot: String,
 }
 
@@ -36,21 +55,42 @@ impl BraceTracker {
         for (pos, ch) in query.char_indices() {
             if !state.is_in_string() {
                 match ch {
-                    '{' => self.open_braces.push((pos, BraceType::Curly)),
-                    '[' => self.open_braces.push((pos, BraceType::Square)),
-                    '(' => self.open_braces.push((pos, BraceType::Paren)),
+                    '{' => self.open_braces.push(BraceInfo {
+                        pos,
+                        brace_type: BraceType::Curly,
+                        context: None,
+                    }),
+                    '[' => self.open_braces.push(BraceInfo {
+                        pos,
+                        brace_type: BraceType::Square,
+                        context: None,
+                    }),
+                    '(' => {
+                        let context = Self::detect_function_context(query, pos);
+                        self.open_braces.push(BraceInfo {
+                            pos,
+                            brace_type: BraceType::Paren,
+                            context,
+                        });
+                    }
                     '}' => {
-                        if let Some((_, BraceType::Curly)) = self.open_braces.last() {
+                        if let Some(info) = self.open_braces.last()
+                            && info.brace_type == BraceType::Curly
+                        {
                             self.open_braces.pop();
                         }
                     }
                     ']' => {
-                        if let Some((_, BraceType::Square)) = self.open_braces.last() {
+                        if let Some(info) = self.open_braces.last()
+                            && info.brace_type == BraceType::Square
+                        {
                             self.open_braces.pop();
                         }
                     }
                     ')' => {
-                        if let Some((_, BraceType::Paren)) = self.open_braces.last() {
+                        if let Some(info) = self.open_braces.last()
+                            && info.brace_type == BraceType::Paren
+                        {
                             self.open_braces.pop();
                         }
                     }
@@ -61,10 +101,60 @@ impl BraceTracker {
         }
     }
 
+    /// Detect if the parenthesis at `paren_pos` is preceded by an element-context function.
+    /// Scans backwards to find a function name, then checks if it's in ELEMENT_CONTEXT_FUNCTIONS.
+    fn detect_function_context(query: &str, paren_pos: usize) -> Option<FunctionContext> {
+        let bytes = query.as_bytes();
+        if paren_pos == 0 {
+            return None;
+        }
+
+        // Skip whitespace before the paren
+        let mut end = paren_pos;
+        while end > 0 && bytes[end - 1].is_ascii_whitespace() {
+            end -= 1;
+        }
+
+        if end == 0 {
+            return None;
+        }
+
+        // Check if there's a word character before the paren
+        if !Self::is_word_char(bytes[end - 1]) {
+            return None;
+        }
+
+        // Find the start of the word
+        let mut start = end - 1;
+        while start > 0 && Self::is_word_char(bytes[start - 1]) {
+            start -= 1;
+        }
+
+        // Extract the function name
+        let func_name = &query[start..end];
+
+        // Look up in JQ_FUNCTION_METADATA to get static str reference
+        let static_name = JQ_FUNCTION_METADATA
+            .iter()
+            .find(|f| f.name == func_name)
+            .map(|f| f.name)?;
+
+        // Check if it's an element-context function
+        if is_element_context_function(static_name) {
+            Some(FunctionContext::ElementIterator(static_name))
+        } else {
+            None
+        }
+    }
+
+    fn is_word_char(b: u8) -> bool {
+        b.is_ascii_alphanumeric() || b == b'_'
+    }
+
     pub fn context_at(&self, pos: usize) -> Option<BraceType> {
-        for (brace_pos, brace_type) in self.open_braces.iter().rev() {
-            if *brace_pos < pos {
-                return Some(*brace_type);
+        for info in self.open_braces.iter().rev() {
+            if info.pos < pos {
+                return Some(info.brace_type);
             }
         }
         None
@@ -72,6 +162,17 @@ impl BraceTracker {
 
     pub fn is_in_object(&self, pos: usize) -> bool {
         self.context_at(pos) == Some(BraceType::Curly)
+    }
+
+    /// Check if the cursor position is inside any element-context function.
+    /// This checks ALL enclosing parens, not just the innermost one,
+    /// so `map(limit(5; .` correctly returns true (map provides element context).
+    pub fn is_in_element_context(&self, pos: usize) -> bool {
+        self.open_braces.iter().any(|info| {
+            info.pos < pos
+                && info.brace_type == BraceType::Paren
+                && matches!(info.context, Some(FunctionContext::ElementIterator(_)))
+        })
     }
 
     #[allow(dead_code)]

--- a/src/autocomplete/context_tests.rs
+++ b/src/autocomplete/context_tests.rs
@@ -679,4 +679,484 @@ proptest! {
             returned_partial
         );
     }
+
+    /// Element context suggestions inside map should not have brackets
+    #[test]
+    fn prop_element_context_suggestions_no_brackets(
+        field_names in prop::collection::vec("[a-z]{1,8}", 1..5),
+    ) {
+        use crate::query::ResultType;
+
+        let query = "map(.";
+        let tracker = tracker_for(query);
+
+        let json_arr: Vec<String> = field_names
+            .iter()
+            .map(|name| format!("{{\"{}\": \"value\"}}", name))
+            .collect();
+        let json_result = format!("[{}]", json_arr.first().unwrap_or(&"{}".to_string()));
+
+        let parsed = serde_json::from_str::<Value>(&json_result).ok().map(Arc::new);
+        let suggestions = get_suggestions(
+            query,
+            query.len(),
+            parsed,
+            Some(ResultType::ArrayOfObjects),
+            &tracker,
+        );
+
+        for suggestion in &suggestions {
+            if suggestion.text != ".[]" {
+                prop_assert!(
+                    !suggestion.text.contains("[]."),
+                    "Element context suggestion '{}' should NOT contain '[].'",
+                    suggestion.text
+                );
+            }
+        }
+    }
+
+    /// Outside element context, array suggestions should have brackets
+    #[test]
+    fn prop_outside_context_suggestions_have_brackets(
+        field_names in prop::collection::vec("[a-z]{1,8}", 1..5),
+    ) {
+        use crate::query::ResultType;
+
+        let query = ".";
+        let tracker = tracker_for(query);
+
+        let json_arr: Vec<String> = field_names
+            .iter()
+            .map(|name| format!("{{\"{}\": \"value\"}}", name))
+            .collect();
+        let json_result = format!("[{}]", json_arr.first().unwrap_or(&"{}".to_string()));
+
+        let parsed = serde_json::from_str::<Value>(&json_result).ok().map(Arc::new);
+        let suggestions = get_suggestions(
+            query,
+            query.len(),
+            parsed,
+            Some(ResultType::ArrayOfObjects),
+            &tracker,
+        );
+
+        let field_suggestions: Vec<_> = suggestions
+            .iter()
+            .filter(|s| s.text != ".[]" && s.text.len() > 1)
+            .collect();
+
+        for suggestion in &field_suggestions {
+            prop_assert!(
+                suggestion.text.contains("[]."),
+                "Outside element context, suggestion '{}' should contain '[].'",
+                suggestion.text
+            );
+        }
+    }
+}
+
+// ============================================================================
+// Element Context Integration Tests
+// ============================================================================
+
+fn create_array_of_objects_json() -> (Arc<Value>, crate::query::ResultType) {
+    use crate::query::ResultType;
+    let json = r#"[{"name": "alice", "age": 30}, {"name": "bob", "age": 25}]"#;
+    let parsed = serde_json::from_str::<Value>(json).unwrap();
+    (Arc::new(parsed), ResultType::ArrayOfObjects)
+}
+
+#[test]
+fn test_suggestions_inside_map_returns_element_fields() {
+    let (parsed, result_type) = create_array_of_objects_json();
+    let query = "map(.";
+    let tracker = tracker_for(query);
+
+    let suggestions = get_suggestions(
+        query,
+        query.len(),
+        Some(parsed),
+        Some(result_type),
+        &tracker,
+    );
+
+    let field_suggestions: Vec<_> = suggestions.iter().filter(|s| s.text != ".[]").collect();
+
+    assert!(
+        !field_suggestions.is_empty(),
+        "Should have field suggestions"
+    );
+
+    for suggestion in field_suggestions {
+        assert!(
+            !suggestion.text.contains("[]."),
+            "Inside map(), suggestion '{}' should not contain '[].'",
+            suggestion.text
+        );
+        assert!(
+            suggestion.text.starts_with('.'),
+            "Field suggestion '{}' should start with '.'",
+            suggestion.text
+        );
+    }
+}
+
+#[test]
+fn test_suggestions_inside_select_returns_element_fields() {
+    let (parsed, result_type) = create_array_of_objects_json();
+    let query = "select(.";
+    let tracker = tracker_for(query);
+
+    let suggestions = get_suggestions(
+        query,
+        query.len(),
+        Some(parsed),
+        Some(result_type),
+        &tracker,
+    );
+
+    let field_suggestions: Vec<_> = suggestions.iter().filter(|s| s.text != ".[]").collect();
+
+    assert!(
+        !field_suggestions.is_empty(),
+        "Should have field suggestions"
+    );
+
+    for suggestion in field_suggestions {
+        assert!(
+            !suggestion.text.contains("[]."),
+            "Inside select(), suggestion '{}' should not contain '[].'",
+            suggestion.text
+        );
+    }
+}
+
+#[test]
+fn test_suggestions_outside_function_returns_array_fields() {
+    let (parsed, result_type) = create_array_of_objects_json();
+    let query = ".";
+    let tracker = tracker_for(query);
+
+    let suggestions = get_suggestions(
+        query,
+        query.len(),
+        Some(parsed),
+        Some(result_type),
+        &tracker,
+    );
+
+    let field_suggestions: Vec<_> = suggestions.iter().filter(|s| s.text != ".[]").collect();
+
+    assert!(
+        !field_suggestions.is_empty(),
+        "Should have field suggestions"
+    );
+
+    for suggestion in field_suggestions {
+        assert!(
+            suggestion.text.contains("[]."),
+            "Outside function, suggestion '{}' should contain '[].'",
+            suggestion.text
+        );
+    }
+}
+
+#[test]
+fn test_suggestions_inside_nested_element_functions() {
+    let (parsed, result_type) = create_array_of_objects_json();
+    let query = "map(select(.";
+    let tracker = tracker_for(query);
+
+    let suggestions = get_suggestions(
+        query,
+        query.len(),
+        Some(parsed),
+        Some(result_type),
+        &tracker,
+    );
+
+    let field_suggestions: Vec<_> = suggestions.iter().filter(|s| s.text != ".[]").collect();
+
+    for suggestion in field_suggestions {
+        assert!(
+            !suggestion.text.contains("[]."),
+            "Inside nested element functions, suggestion '{}' should not contain '[].'",
+            suggestion.text
+        );
+    }
+}
+
+#[test]
+fn test_suggestions_inside_map_with_object_construction() {
+    let (parsed, result_type) = create_array_of_objects_json();
+    let query = "map({name: .";
+    let tracker = tracker_for(query);
+
+    let suggestions = get_suggestions(
+        query,
+        query.len(),
+        Some(parsed),
+        Some(result_type),
+        &tracker,
+    );
+
+    let field_suggestions: Vec<_> = suggestions.iter().filter(|s| s.text != ".[]").collect();
+
+    for suggestion in field_suggestions {
+        assert!(
+            !suggestion.text.contains("[]."),
+            "Inside map() with object, suggestion '{}' should not contain '[].'",
+            suggestion.text
+        );
+    }
+}
+
+#[test]
+fn test_suggestions_partial_field_filtering_in_element_context() {
+    let (parsed, result_type) = create_array_of_objects_json();
+    let query = "map(.na";
+    let tracker = tracker_for(query);
+
+    let suggestions = get_suggestions(
+        query,
+        query.len(),
+        Some(parsed),
+        Some(result_type),
+        &tracker,
+    );
+
+    assert!(
+        suggestions.iter().any(|s| s.text == ".name"),
+        "Should suggest '.name' for partial 'na'"
+    );
+
+    assert!(
+        !suggestions.iter().any(|s| s.text == ".age"),
+        "Should not suggest '.age' for partial 'na'"
+    );
+}
+
+#[test]
+fn test_suggestions_after_pipe_in_element_context() {
+    let (parsed, result_type) = create_array_of_objects_json();
+    let query = "map(. | .";
+    let tracker = tracker_for(query);
+
+    let suggestions = get_suggestions(
+        query,
+        query.len(),
+        Some(parsed),
+        Some(result_type),
+        &tracker,
+    );
+
+    let field_suggestions: Vec<_> = suggestions.iter().filter(|s| s.text != ".[]").collect();
+
+    for suggestion in field_suggestions {
+        assert!(
+            !suggestion.text.contains("[]."),
+            "After pipe inside map(), suggestion '{}' should not contain '[].'",
+            suggestion.text
+        );
+    }
+}
+
+#[test]
+fn test_suggestions_all_element_functions() {
+    let (parsed, result_type) = create_array_of_objects_json();
+    let element_functions = [
+        "map",
+        "select",
+        "sort_by",
+        "group_by",
+        "unique_by",
+        "min_by",
+        "max_by",
+        "recurse",
+        "walk",
+    ];
+
+    for func in element_functions {
+        let query = format!("{}(.", func);
+        let tracker = tracker_for(&query);
+
+        let suggestions = get_suggestions(
+            &query,
+            query.len(),
+            Some(parsed.clone()),
+            Some(result_type.clone()),
+            &tracker,
+        );
+
+        let field_suggestions: Vec<_> = suggestions.iter().filter(|s| s.text != ".[]").collect();
+
+        for suggestion in &field_suggestions {
+            assert!(
+                !suggestion.text.contains("[]."),
+                "Inside {}(), suggestion '{}' should not contain '[].'",
+                func,
+                suggestion.text
+            );
+        }
+    }
+}
+
+#[test]
+fn test_suggestions_non_element_functions_have_brackets() {
+    let (parsed, result_type) = create_array_of_objects_json();
+    let non_element_functions = ["limit", "has", "del"];
+
+    for func in non_element_functions {
+        let query = format!("{}(.", func);
+        let tracker = tracker_for(&query);
+
+        let suggestions = get_suggestions(
+            &query,
+            query.len(),
+            Some(parsed.clone()),
+            Some(result_type.clone()),
+            &tracker,
+        );
+
+        let field_suggestions: Vec<_> = suggestions.iter().filter(|s| s.text != ".[]").collect();
+
+        for suggestion in &field_suggestions {
+            assert!(
+                suggestion.text.contains("[]."),
+                "Inside {}() (non-element function), suggestion '{}' should contain '[].'",
+                func,
+                suggestion.text
+            );
+        }
+    }
+}
+
+#[test]
+fn test_regression_existing_field_suggestions_unchanged() {
+    use crate::query::ResultType;
+
+    let json = r#"{"name": "test", "value": 42}"#;
+    let parsed = Arc::new(serde_json::from_str::<Value>(json).unwrap());
+    let query = ".";
+    let tracker = tracker_for(query);
+
+    let suggestions = get_suggestions(
+        query,
+        query.len(),
+        Some(parsed),
+        Some(ResultType::Object),
+        &tracker,
+    );
+
+    assert!(
+        suggestions.iter().any(|s| s.text == ".name"),
+        "Should suggest '.name' for object"
+    );
+    assert!(
+        suggestions.iter().any(|s| s.text == ".value"),
+        "Should suggest '.value' for object"
+    );
+}
+
+#[test]
+fn test_regression_object_key_context_unchanged() {
+    use crate::query::ResultType;
+
+    let json = r#"{"name": "test", "value": 42}"#;
+    let parsed = Arc::new(serde_json::from_str::<Value>(json).unwrap());
+    let query = "{na";
+    let tracker = tracker_for(query);
+
+    let suggestions = get_suggestions(
+        query,
+        query.len(),
+        Some(parsed),
+        Some(ResultType::Object),
+        &tracker,
+    );
+
+    for suggestion in &suggestions {
+        assert!(
+            !suggestion.text.starts_with('.'),
+            "ObjectKeyContext suggestion '{}' should not start with '.'",
+            suggestion.text
+        );
+    }
+}
+
+#[test]
+fn test_regression_function_context_unchanged() {
+    use crate::query::ResultType;
+
+    let json = r#"{"name": "test"}"#;
+    let parsed = Arc::new(serde_json::from_str::<Value>(json).unwrap());
+    let query = "ma";
+    let tracker = tracker_for(query);
+
+    let suggestions = get_suggestions(
+        query,
+        query.len(),
+        Some(parsed),
+        Some(ResultType::Object),
+        &tracker,
+    );
+
+    assert!(
+        suggestions.iter().any(|s| s.text == "map"),
+        "Should suggest 'map' function for partial 'ma'"
+    );
+}
+
+#[test]
+fn test_object_key_context_does_not_suggest_iterator() {
+    use crate::query::ResultType;
+
+    // Array of objects - normally would suggest .[]
+    let json = r#"[{"name": "test", "id": 1}]"#;
+    let parsed = Arc::new(serde_json::from_str::<Value>(json).unwrap());
+    let query = "{na";
+    let tracker = tracker_for(query);
+
+    let suggestions = get_suggestions(
+        query,
+        query.len(),
+        Some(parsed),
+        Some(ResultType::ArrayOfObjects),
+        &tracker,
+    );
+
+    // Should NOT suggest .[] in object key context
+    assert!(
+        !suggestions
+            .iter()
+            .any(|s| s.text == "[]" || s.text == ".[]"),
+        "Should not suggest [] or .[] in object key context"
+    );
+}
+
+#[test]
+fn test_field_context_inside_object_suggests_array_fields() {
+    use crate::query::ResultType;
+
+    // Array of objects - when inside {.field}, should suggest .[].field (normal array behavior)
+    // Only element-context functions suppress the .[]. prefix
+    let json = r#"[{"serviceName": "test", "id": 1}]"#;
+    let parsed = Arc::new(serde_json::from_str::<Value>(json).unwrap());
+    let query = "{.ser";
+    let tracker = tracker_for(query);
+
+    let suggestions = get_suggestions(
+        query,
+        query.len(),
+        Some(parsed),
+        Some(ResultType::ArrayOfObjects),
+        &tracker,
+    );
+
+    // Should suggest .[].serviceName (normal array of objects behavior)
+    assert!(
+        suggestions.iter().any(|s| s.text == ".[].serviceName"),
+        "Should suggest .[].serviceName inside object construction"
+    );
 }

--- a/src/autocomplete/jq_functions.rs
+++ b/src/autocomplete/jq_functions.rs
@@ -1,4 +1,5 @@
 use super::autocomplete_state::{Suggestion, SuggestionType};
+use std::collections::HashSet;
 use std::sync::LazyLock;
 
 /// Metadata for a jq built-in function
@@ -218,6 +219,32 @@ pub static JQ_FUNCTION_METADATA: &[JqFunction] = &[
     ),
     JqFunction::new("env", "env", "Access environment variables", false),
 ];
+
+/// Functions that provide element context for their arguments.
+/// Inside these functions, `.` refers to each element of the input array,
+/// so autocomplete should suggest `.field` instead of `.[].field`.
+pub static ELEMENT_CONTEXT_FUNCTIONS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    [
+        "map",
+        "select",
+        "sort_by",
+        "group_by",
+        "unique_by",
+        "min_by",
+        "max_by",
+        "recurse",
+        "walk",
+    ]
+    .into_iter()
+    .collect()
+});
+
+/// Check if a function provides element context for its arguments.
+/// When true, autocomplete inside this function should suggest element fields
+/// directly (`.field`) rather than array iteration (`.[].field`).
+pub fn is_element_context_function(name: &str) -> bool {
+    ELEMENT_CONTEXT_FUNCTIONS.contains(name)
+}
 
 /// Static list of all jq built-in functions, operators, and patterns
 /// Built once at first access and reused for performance

--- a/src/autocomplete/jq_functions_tests.rs
+++ b/src/autocomplete/jq_functions_tests.rs
@@ -273,4 +273,141 @@ proptest! {
             func.signature
         );
     }
+
+    /// All element context functions should be recognized by is_element_context_function
+    #[test]
+    fn prop_element_context_functions_recognized(
+        func in prop_oneof![
+            Just("map"),
+            Just("select"),
+            Just("sort_by"),
+            Just("group_by"),
+            Just("unique_by"),
+            Just("min_by"),
+            Just("max_by"),
+            Just("recurse"),
+            Just("walk")
+        ]
+    ) {
+        prop_assert!(
+            is_element_context_function(func),
+            "Function '{}' should be recognized as element context function",
+            func
+        );
+    }
+
+    /// Non-element functions should not be recognized as element context
+    #[test]
+    fn prop_non_element_functions_not_recognized(
+        func in prop_oneof![
+            Just("limit"),
+            Just("has"),
+            Just("del"),
+            Just("getpath"),
+            Just("split"),
+            Just("join"),
+            Just("test"),
+            Just("match"),
+            Just("keys"),
+            Just("values"),
+            Just("length"),
+            Just("first"),
+            Just("last")
+        ]
+    ) {
+        prop_assert!(
+            !is_element_context_function(func),
+            "Function '{}' should NOT be recognized as element context function",
+            func
+        );
+    }
+}
+
+// ============================================================================
+// Element Context Functions Tests
+// ============================================================================
+
+#[test]
+fn test_element_context_functions_contains_map() {
+    assert!(
+        ELEMENT_CONTEXT_FUNCTIONS.contains("map"),
+        "ELEMENT_CONTEXT_FUNCTIONS should contain 'map'"
+    );
+}
+
+#[test]
+fn test_element_context_functions_contains_all_expected() {
+    let expected = [
+        "map",
+        "select",
+        "sort_by",
+        "group_by",
+        "unique_by",
+        "min_by",
+        "max_by",
+        "recurse",
+        "walk",
+    ];
+
+    for func in expected {
+        assert!(
+            ELEMENT_CONTEXT_FUNCTIONS.contains(func),
+            "ELEMENT_CONTEXT_FUNCTIONS should contain '{}'",
+            func
+        );
+    }
+}
+
+#[test]
+fn test_element_context_functions_excludes_non_element() {
+    let non_element = [
+        "limit", "has", "del", "getpath", "keys", "values", "length", "add",
+    ];
+
+    for func in non_element {
+        assert!(
+            !ELEMENT_CONTEXT_FUNCTIONS.contains(func),
+            "ELEMENT_CONTEXT_FUNCTIONS should NOT contain '{}'",
+            func
+        );
+    }
+}
+
+#[test]
+fn test_is_element_context_function_helper() {
+    assert!(is_element_context_function("map"));
+    assert!(is_element_context_function("select"));
+    assert!(is_element_context_function("sort_by"));
+    assert!(is_element_context_function("group_by"));
+    assert!(is_element_context_function("unique_by"));
+    assert!(is_element_context_function("min_by"));
+    assert!(is_element_context_function("max_by"));
+    assert!(is_element_context_function("recurse"));
+    assert!(is_element_context_function("walk"));
+
+    assert!(!is_element_context_function("limit"));
+    assert!(!is_element_context_function("has"));
+    assert!(!is_element_context_function("del"));
+    assert!(!is_element_context_function("unknown_function"));
+}
+
+#[test]
+fn test_element_context_functions_count() {
+    assert_eq!(
+        ELEMENT_CONTEXT_FUNCTIONS.len(),
+        9,
+        "ELEMENT_CONTEXT_FUNCTIONS should contain exactly 9 functions"
+    );
+}
+
+#[test]
+fn test_element_context_functions_all_in_metadata() {
+    for func in ELEMENT_CONTEXT_FUNCTIONS.iter() {
+        let found = JQ_FUNCTION_METADATA.iter().any(|f| f.name == *func);
+        assert!(
+            found,
+            "Element context function '{}' should be in JQ_FUNCTION_METADATA",
+            func
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Fix autocomplete suggestions inside element-context functions like `map()`, `select()`, `sort_by()`, etc.
- When typing `.array | map(.<tab>)`, autocomplete now correctly suggests `.field` instead of `.[].field` since iteration is already provided by the function
- Suppress `.[]` suggestion in ObjectKeyContext where it's not applicable

## Changes

- Add `ELEMENT_CONTEXT_FUNCTIONS` HashSet for O(1) lookup of element-iterating functions
- Extend `BraceTracker` with `FunctionContext` enum and `BraceInfo` struct to track function context
- Add `is_in_element_context()` method to detect when cursor is inside element-iterating functions
- Add `suppress_array_brackets` parameter to `ResultAnalyzer` to control suggestion format
- Comprehensive test coverage with unit, integration, and property-based tests

## Test plan

- [x] `cargo build --release` - zero warnings
- [x] `cargo clippy --all-targets --all-features` - zero lints  
- [x] `cargo fmt --all --check` - clean
- [x] `cargo test --lib` - 1467 tests pass
- [ ] Manual TUI validation:
  - Type `map(.` and press Tab → should suggest `.field` not `.[].field`
  - Type `select(.` and press Tab → should suggest `.field` not `.[].field`
  - Type `.` outside functions → should suggest `.[].field` and `.[]`
  - Type `{na` and press Tab → should suggest `name` without dots