### PR TITLE
Remove AI response word limit constraints

### DIFF
--- a/src/ai/ai_events.rs
+++ b/src/ai/ai_events.rs
@@ -190,8 +190,7 @@ pub fn handle_execution_result(
                     Some(error.to_string()),
                     params,
                 );
-                let word_limit = ai_state.word_limit;
-                let prompt = build_prompt(&context, word_limit);
+                let prompt = build_prompt(&context);
                 ai_state.send_request(prompt);
             }
         }
@@ -209,8 +208,7 @@ pub fn handle_execution_result(
                         base_query_result: None,
                     },
                 );
-                let word_limit = ai_state.word_limit;
-                let prompt = build_prompt(&context, word_limit);
+                let prompt = build_prompt(&context);
                 ai_state.send_request(prompt);
             }
         }

--- a/src/ai/ai_render.rs
+++ b/src/ai/ai_render.rs
@@ -21,7 +21,6 @@ use super::render::layout;
 pub use self::content::build_content;
 pub use layout::{
     AUTOCOMPLETE_RESERVED_WIDTH, calculate_popup_area, calculate_popup_area_with_height,
-    calculate_word_limit,
 };
 
 // Module declarations - only content is local
@@ -189,7 +188,7 @@ fn render_suggestions_as_widgets(
 /// Render the AI assistant popup
 ///
 /// # Arguments
-/// * `ai_state` - The current AI state (mutable to update word_limit)
+/// * `ai_state` - The current AI state
 /// * `frame` - The frame to render to
 /// * `input_area` - The input bar area (popup renders above this)
 pub fn render_popup(ai_state: &mut AiState, frame: &mut Frame, input_area: Rect) {
@@ -242,8 +241,6 @@ pub fn render_popup(ai_state: &mut AiState, frame: &mut Frame, input_area: Rect)
             None => return,
         }
     };
-
-    ai_state.word_limit = calculate_word_limit(popup_area.width, popup_area.height);
 
     popup::clear_area(frame, popup_area);
 

--- a/src/ai/ai_render_tests/layout_tests.rs
+++ b/src/ai/ai_render_tests/layout_tests.rs
@@ -169,51 +169,6 @@ proptest! {
     }
 }
 
-// **Feature: ai-assistant-phase2, Property 4: Word limit formula correctness**
-// *For any* popup dimensions (w, h), the word limit SHALL equal clamp((w-4)*(h-2)/5, 100, 800).
-// **Validates: Requirements 7.1, 7.2, 7.3**
-proptest! {
-    #![proptest_config(ProptestConfig::with_cases(100))]
-
-    #[test]
-    fn prop_word_limit_formula_correctness(
-        width in 40u16..200u16,
-        height in 6u16..50u16
-    ) {
-        let result = calculate_word_limit(width, height);
-        let content_width = width.saturating_sub(4);
-        let content_height = height.saturating_sub(2);
-        let expected_raw = (content_width as u32 * content_height as u32) / 5;
-        let expected = expected_raw.clamp(100, 800) as u16;
-
-        prop_assert_eq!(
-            result, expected,
-            "Word limit for {}x{} should be {} (raw: {})",
-            width, height, expected, expected_raw
-        );
-    }
-}
-
-// **Feature: ai-assistant-phase2, Property 5: Word limit determinism**
-// *For any* given popup dimensions, calling calculate_word_limit multiple times SHALL return the same value.
-// **Validates: Requirements 7.5**
-proptest! {
-    #![proptest_config(ProptestConfig::with_cases(100))]
-
-    #[test]
-    fn prop_word_limit_determinism(
-        width in 40u16..200u16,
-        height in 6u16..50u16
-    ) {
-        let result1 = calculate_word_limit(width, height);
-        let result2 = calculate_word_limit(width, height);
-        let result3 = calculate_word_limit(width, height);
-
-        prop_assert_eq!(result1, result2, "Word limit should be deterministic");
-        prop_assert_eq!(result2, result3, "Word limit should be deterministic");
-    }
-}
-
 // =========================================================================
 // Unit Tests
 // =========================================================================
@@ -287,52 +242,4 @@ fn test_calculate_popup_area_minimum_viable() {
 
     let area = area.unwrap();
     assert!(area.width >= AI_POPUP_MIN_WIDTH);
-}
-
-// =========================================================================
-// Word Limit Unit Tests (Phase 2)
-// =========================================================================
-
-#[test]
-fn test_word_limit_minimum_clamp() {
-    // Very small dimensions should clamp to 100
-    let result = calculate_word_limit(10, 5);
-    assert_eq!(result, 100);
-}
-
-#[test]
-fn test_word_limit_maximum_clamp() {
-    // Very large dimensions should clamp to 800
-    let result = calculate_word_limit(200, 100);
-    assert_eq!(result, 800);
-}
-
-#[test]
-fn test_word_limit_typical_small() {
-    // 44 width, 8 height: (44-4)*(8-2)/5 = 40*6/5 = 48 -> clamped to 100
-    let result = calculate_word_limit(44, 8);
-    assert_eq!(result, 100);
-}
-
-#[test]
-fn test_word_limit_typical_medium() {
-    // 60 width, 15 height: (60-4)*(15-2)/5 = 56*13/5 = 145
-    let result = calculate_word_limit(60, 15);
-    assert_eq!(result, 145);
-}
-
-#[test]
-fn test_word_limit_typical_large() {
-    // 80 width, 20 height: (80-4)*(20-2)/5 = 76*18/5 = 273
-    let result = calculate_word_limit(80, 20);
-    assert_eq!(result, 273);
-}
-
-#[test]
-fn test_word_limit_boundary_100() {
-    // Find dimensions that give exactly 100 (or just above)
-    // (w-4)*(h-2)/5 = 100 -> (w-4)*(h-2) = 500
-    // e.g., 44 width, 14 height: 40*12/5 = 96 -> clamped to 100
-    let result = calculate_word_limit(44, 14);
-    assert_eq!(result, 100);
 }

--- a/src/ai/ai_state.rs
+++ b/src/ai/ai_state.rs
@@ -102,9 +102,6 @@ pub struct AiState {
     /// Parsed suggestions from AI response
     /// Empty if response couldn't be parsed into structured suggestions
     pub suggestions: Vec<Suggestion>,
-    /// Current word limit based on popup dimensions
-    /// Updated when popup is rendered, used for next AI request
-    pub word_limit: u16,
     /// Selection state for suggestion navigation
     /// Tracks which suggestion is selected and navigation mode
     pub selection: SelectionState,

--- a/src/ai/ai_state/lifecycle.rs
+++ b/src/ai/ai_state/lifecycle.rs
@@ -30,7 +30,6 @@ impl AiState {
             in_flight_request_id: None,
             current_cancel_token: None,
             suggestions: Vec::new(),
-            word_limit: 200,
             selection: SelectionState::new(),
             previous_popup_height: None,
         }
@@ -66,7 +65,6 @@ impl AiState {
             in_flight_request_id: None,
             current_cancel_token: None,
             suggestions: Vec::new(),
-            word_limit: 200,
             selection: SelectionState::new(),
             previous_popup_height: None,
         }

--- a/src/ai/prompt.rs
+++ b/src/ai/prompt.rs
@@ -9,11 +9,11 @@ use super::context::QueryContext;
 ///
 /// Dispatches to either error troubleshooting or success optimization prompt
 /// based on the `is_success` field in the context.
-pub fn build_prompt(context: &QueryContext, word_limit: u16) -> String {
+pub fn build_prompt(context: &QueryContext) -> String {
     if context.is_success {
-        build_success_prompt(context, word_limit)
+        build_success_prompt(context)
     } else {
-        build_error_prompt(context, word_limit)
+        build_error_prompt(context)
     }
 }
 
@@ -22,15 +22,10 @@ pub fn build_prompt(context: &QueryContext, word_limit: u16) -> String {
 /// Creates a prose prompt that includes the query, error message,
 /// JSON sample, and structure information to help the AI provide
 /// relevant assistance.
-pub fn build_error_prompt(context: &QueryContext, word_limit: u16) -> String {
+pub fn build_error_prompt(context: &QueryContext) -> String {
     let mut prompt = String::new();
 
     prompt.push_str("You are a jq query assistant helping troubleshoot errors.\n");
-    prompt.push_str("CRITICAL: Your response will be displayed in a popup window.\n");
-    prompt.push_str(&format!(
-        "Keep your ENTIRE response under {} words.\n\n",
-        word_limit
-    ));
 
     prompt.push_str("## Current Query\n");
     prompt.push_str(&format!("```\n{}\n```\n", context.query));
@@ -92,11 +87,6 @@ pub fn build_error_prompt(context: &QueryContext, word_limit: u16) -> String {
         "Entire query is natural language. Interpret intent and provide [Next] suggestions.\n\n",
     );
 
-    prompt.push_str(&format!(
-        "REMEMBER: Total response must be under {} words.\n",
-        word_limit
-    ));
-
     prompt
 }
 
@@ -104,15 +94,10 @@ pub fn build_error_prompt(context: &QueryContext, word_limit: u16) -> String {
 ///
 /// Creates a prose prompt that includes the query, output sample,
 /// and structure information to help the AI suggest optimizations.
-pub fn build_success_prompt(context: &QueryContext, word_limit: u16) -> String {
+pub fn build_success_prompt(context: &QueryContext) -> String {
     let mut prompt = String::new();
 
     prompt.push_str("You are a jq query assistant helping optimize queries.\n");
-    prompt.push_str("CRITICAL: Your response will be displayed in a popup window.\n");
-    prompt.push_str(&format!(
-        "Keep your ENTIRE response under {} words.\n\n",
-        word_limit
-    ));
 
     prompt.push_str("## Current Query\n");
     prompt.push_str(&format!("```\n{}\n```\n\n", context.query));
@@ -160,11 +145,6 @@ pub fn build_success_prompt(context: &QueryContext, word_limit: u16) -> String {
     prompt.push_str(
         "Entire query is natural language. Interpret intent and provide [Next] suggestions.\n\n",
     );
-
-    prompt.push_str(&format!(
-        "REMEMBER: Total response must be under {} words.\n",
-        word_limit
-    ));
 
     prompt
 }

--- a/src/ai/prompt_tests.rs
+++ b/src/ai/prompt_tests.rs
@@ -19,7 +19,7 @@ fn test_build_error_prompt_includes_query() {
         base_query_result: None,
     };
 
-    let prompt = build_error_prompt(&ctx, 200);
+    let prompt = build_error_prompt(&ctx);
     assert!(prompt.contains(".name"));
     assert!(prompt.contains("syntax error"));
     assert!(prompt.contains("Cursor position: 5"));
@@ -41,7 +41,7 @@ fn test_build_error_prompt_includes_json_sample() {
         base_query_result: None,
     };
 
-    let prompt = build_error_prompt(&ctx, 200);
+    let prompt = build_error_prompt(&ctx);
     assert!(prompt.contains(r#"{"key": "value"}"#));
 }
 
@@ -61,7 +61,7 @@ fn test_build_error_prompt_includes_schema() {
         base_query_result: None,
     };
 
-    let prompt = build_error_prompt(&ctx, 200);
+    let prompt = build_error_prompt(&ctx);
     assert!(prompt.contains("## Input JSON Schema"));
     assert!(prompt.contains(r#"{"name":"string","age":"number"}"#));
 }
@@ -153,7 +153,7 @@ fn test_build_success_prompt_includes_query() {
         base_query_result: None,
     };
 
-    let prompt = build_success_prompt(&ctx, 200);
+    let prompt = build_success_prompt(&ctx);
     assert!(prompt.contains(".items[]"));
     assert!(prompt.contains("optimize"));
 }
@@ -174,7 +174,7 @@ fn test_build_success_prompt_includes_output_sample() {
         base_query_result: None,
     };
 
-    let prompt = build_success_prompt(&ctx, 200);
+    let prompt = build_success_prompt(&ctx);
     assert!(prompt.contains(r#""test""#));
     assert!(prompt.contains("Query Output Sample"));
 }
@@ -195,7 +195,7 @@ fn test_build_success_prompt_includes_schema() {
         base_query_result: None,
     };
 
-    let prompt = build_success_prompt(&ctx, 200);
+    let prompt = build_success_prompt(&ctx);
     assert!(prompt.contains("## Input JSON Schema"));
     assert!(prompt.contains(r#"["number"]"#));
 }
@@ -216,7 +216,7 @@ fn test_build_prompt_dispatches_to_error_prompt() {
         base_query_result: None,
     };
 
-    let prompt = build_prompt(&ctx, 200);
+    let prompt = build_prompt(&ctx);
     // Error prompt contains "troubleshoot" and error message
     assert!(prompt.contains("troubleshoot"));
     assert!(prompt.contains("syntax error"));
@@ -238,30 +238,10 @@ fn test_build_prompt_dispatches_to_success_prompt() {
         base_query_result: None,
     };
 
-    let prompt = build_prompt(&ctx, 200);
+    let prompt = build_prompt(&ctx);
     // Success prompt contains "optimize"
     assert!(prompt.contains("optimize"));
     assert!(!prompt.contains("troubleshoot"));
-}
-
-#[test]
-fn test_build_prompt_includes_word_limit() {
-    let ctx = QueryContext {
-        query: ".name".to_string(),
-        cursor_pos: 5,
-        input_sample: "{}".to_string(),
-        output: None,
-        output_sample: None,
-        error: Some("error".to_string()),
-        json_type_info: JsonTypeInfo::default(),
-        is_success: false,
-        input_schema: None,
-        base_query: None,
-        base_query_result: None,
-    };
-
-    let prompt = build_prompt(&ctx, 300);
-    assert!(prompt.contains("300 words"));
 }
 
 #[test]
@@ -280,7 +260,7 @@ fn test_build_error_prompt_includes_structured_format() {
         base_query_result: None,
     };
 
-    let prompt = build_error_prompt(&ctx, 200);
+    let prompt = build_error_prompt(&ctx);
     assert!(prompt.contains("[Fix]"));
     assert!(prompt.contains("[Optimize]"));
     assert!(prompt.contains("[Next]"));
@@ -303,7 +283,7 @@ fn test_build_success_prompt_includes_structured_format() {
         base_query_result: None,
     };
 
-    let prompt = build_success_prompt(&ctx, 200);
+    let prompt = build_success_prompt(&ctx);
     assert!(prompt.contains("[Optimize]"));
     assert!(prompt.contains("[Next]"));
     assert!(prompt.contains("numbered suggestions"));
@@ -325,7 +305,7 @@ fn test_build_prompt_includes_natural_language_instructions() {
         base_query_result: None,
     };
 
-    let prompt = build_error_prompt(&ctx, 200);
+    let prompt = build_error_prompt(&ctx);
     assert!(prompt.contains("Natural Language"));
     assert!(prompt.contains("natural language"));
 }
@@ -346,7 +326,7 @@ fn test_error_prompt_includes_base_query() {
         base_query_result: Some(r#""test""#.to_string()),
     };
 
-    let prompt = build_error_prompt(&ctx, 200);
+    let prompt = build_error_prompt(&ctx);
     assert!(prompt.contains("## Last Working Query"));
     assert!(prompt.contains(".name"));
     assert!(prompt.contains("## Its Output"));
@@ -369,7 +349,7 @@ fn test_error_prompt_without_base_query() {
         base_query_result: None,
     };
 
-    let prompt = build_error_prompt(&ctx, 200);
+    let prompt = build_error_prompt(&ctx);
     assert!(!prompt.contains("Last Working Query"));
 }
 
@@ -389,7 +369,7 @@ fn test_success_prompt_excludes_base_query() {
         base_query_result: Some("old result".to_string()),
     };
 
-    let prompt = build_success_prompt(&ctx, 200);
+    let prompt = build_success_prompt(&ctx);
     assert!(!prompt.contains("Last Working Query"));
     assert!(!prompt.contains(".old"));
 }

--- a/src/ai/render/layout.rs
+++ b/src/ai/render/layout.rs
@@ -102,13 +102,3 @@ pub fn calculate_popup_area_with_height(
         height: popup_height,
     })
 }
-
-/// Calculate dynamic word limit based on popup dimensions
-///
-/// Formula: (width - 4) * (height - 2) / 5, clamped to 100-800
-pub fn calculate_word_limit(width: u16, height: u16) -> u16 {
-    let content_width = width.saturating_sub(4);
-    let content_height = height.saturating_sub(2);
-    let raw_limit = (content_width as u32 * content_height as u32) / 5;
-    raw_limit.clamp(100, 800) as u16
-}


### PR DESCRIPTION
## Summary
- Remove word_limit field and all related functionality from AI state management
- Remove calculate_word_limit() function from layout calculations
- Remove word limit parameter from prompt building functions
- Remove word limit instructions from AI prompts

## Rationale
The word limit was unnecessary because:
1. Only parsed suggestions (query, description, type) are displayed in the popup, not the full AI response
2. The popup has max width/height constraints that handle overflow
3. Content that exceeds available space is cut off (scrolling to be implemented later)

## Changes
- Removed `word_limit` field from `AiState` struct
- Updated prompt functions to remove word_limit parameter
- Removed word limit instructions from error and success prompts
- Removed 8 word_limit related tests
- All 1609 tests passing

## Test Plan
- ✅ All unit tests pass (1585)
- ✅ All integration tests pass (24)
- ✅ No clippy warnings
- ✅ No build warnings
- ✅ Code properly formatted