### PR TITLE
fix(ai): Fix token overflow and enhance context

### DIFF
--- a/src/ai/ai_events.rs
+++ b/src/ai/ai_events.rs
@@ -202,11 +202,7 @@ pub fn handle_execution_result(
                     json_input,
                     Some(output.clone()),
                     None,
-                    ContextParams {
-                        input_schema: params.input_schema,
-                        base_query: None, // Not needed on success
-                        base_query_result: None,
-                    },
+                    params,
                 );
                 let prompt = build_prompt(&context);
                 ai_state.send_request(prompt);

--- a/src/ai/ai_events_tests/integration_tests.rs
+++ b/src/ai/ai_events_tests/integration_tests.rs
@@ -8,6 +8,7 @@ fn empty_params() -> ContextParams<'static> {
         input_schema: None,
         base_query: None,
         base_query_result: None,
+        is_empty_result: false,
     }
 }
 
@@ -210,6 +211,7 @@ fn test_schema_passed_to_ai_on_success() {
             input_schema: schema,
             base_query: None,
             base_query_result: None,
+            is_empty_result: false,
         },
     );
 
@@ -244,6 +246,7 @@ fn test_base_query_passed_on_error() {
             input_schema: schema,
             base_query: Some(".name"),
             base_query_result: Some(r#""test""#),
+            is_empty_result: false,
         },
     );
 
@@ -279,6 +282,7 @@ fn test_base_query_not_passed_on_success() {
             input_schema: None,
             base_query: Some(".old"), // Even though provided
             base_query_result: Some("old output"),
+            is_empty_result: false,
         },
     );
 

--- a/src/ai/ai_events_tests/query_result_tests.rs
+++ b/src/ai/ai_events_tests/query_result_tests.rs
@@ -8,6 +8,7 @@ fn empty_params() -> ContextParams<'static> {
         input_schema: None,
         base_query: None,
         base_query_result: None,
+        is_empty_result: false,
     }
 }
 

--- a/src/ai/context_tests.rs
+++ b/src/ai/context_tests.rs
@@ -8,6 +8,7 @@ fn empty_params() -> ContextParams<'static> {
         input_schema: None,
         base_query: None,
         base_query_result: None,
+        is_empty_result: false,
     }
 }
 
@@ -124,6 +125,7 @@ fn test_query_context_is_complete() {
         error: None,
         json_type_info: JsonTypeInfo::default(),
         is_success: true,
+        is_empty_result: false,
         input_schema: None,
         base_query: None,
         base_query_result: None,
@@ -652,6 +654,7 @@ fn test_query_context_applies_prepare_to_base_query_result() {
         input_schema: None,
         base_query: Some(".base"),
         base_query_result: Some(&large_result),
+        is_empty_result: false,
     };
 
     let ctx = QueryContext::new(

--- a/src/ai/prompt.rs
+++ b/src/ai/prompt.rs
@@ -41,9 +41,6 @@ pub fn build_error_prompt(context: &QueryContext) -> String {
         prompt.push_str(&format!("```json\n{}\n```\n\n", schema));
     }
 
-    prompt.push_str("## Input JSON Sample\n");
-    prompt.push_str(&format!("```json\n{}\n```\n\n", context.input_sample));
-
     if let Some(ref base_query) = context.base_query {
         prompt.push_str("## Last Working Query\n");
         prompt.push_str(&format!("```\n{}\n```\n\n", base_query));
@@ -100,7 +97,8 @@ pub fn build_success_prompt(context: &QueryContext) -> String {
     prompt.push_str("You are a jq query assistant helping optimize queries.\n");
 
     prompt.push_str("## Current Query\n");
-    prompt.push_str(&format!("```\n{}\n```\n\n", context.query));
+    prompt.push_str(&format!("```\n{}\n```\n", context.query));
+    prompt.push_str(&format!("Cursor position: {}\n\n", context.cursor_pos));
 
     if let Some(ref schema) = context.input_schema {
         prompt.push_str("## Input JSON Schema\n");
@@ -110,6 +108,18 @@ pub fn build_success_prompt(context: &QueryContext) -> String {
     if let Some(ref output_sample) = context.output_sample {
         prompt.push_str("## Query Output Sample\n");
         prompt.push_str(&format!("```json\n{}\n```\n\n", output_sample));
+    }
+
+    if context.is_empty_result
+        && let Some(ref base_query) = context.base_query
+    {
+        prompt.push_str("## Last Non-Empty Query\n");
+        prompt.push_str(&format!("```\n{}\n```\n\n", base_query));
+
+        if let Some(ref result) = context.base_query_result {
+            prompt.push_str("## Its Output (displayed in results)\n");
+            prompt.push_str(&format!("```json\n{}\n```\n\n", result));
+        }
     }
 
     prompt.push_str("## Response Format\n");

--- a/src/ai/prompt_tests.rs
+++ b/src/ai/prompt_tests.rs
@@ -14,6 +14,7 @@ fn test_build_error_prompt_includes_query() {
         error: Some("syntax error".to_string()),
         json_type_info: JsonTypeInfo::default(),
         is_success: false,
+        is_empty_result: false,
         input_schema: None,
         base_query: None,
         base_query_result: None,
@@ -26,7 +27,7 @@ fn test_build_error_prompt_includes_query() {
 }
 
 #[test]
-fn test_build_error_prompt_includes_json_sample() {
+fn test_build_error_prompt_excludes_json_sample() {
     let ctx = QueryContext {
         query: ".".to_string(),
         cursor_pos: 1,
@@ -36,13 +37,14 @@ fn test_build_error_prompt_includes_json_sample() {
         error: Some("error".to_string()),
         json_type_info: JsonTypeInfo::default(),
         is_success: false,
+        is_empty_result: false,
         input_schema: None,
         base_query: None,
         base_query_result: None,
     };
 
     let prompt = build_error_prompt(&ctx);
-    assert!(prompt.contains(r#"{"key": "value"}"#));
+    assert!(!prompt.contains("## Input JSON Sample"));
 }
 
 #[test]
@@ -56,6 +58,7 @@ fn test_build_error_prompt_includes_schema() {
         error: Some("error".to_string()),
         json_type_info: JsonTypeInfo::default(),
         is_success: false,
+        is_empty_result: false,
         input_schema: Some(r#"{"name":"string","age":"number"}"#.to_string()),
         base_query: None,
         base_query_result: None,
@@ -83,6 +86,7 @@ fn test_build_help_prompt_basic() {
             schema_hint: "Array of 3 numbers".to_string(),
         },
         is_success: true,
+        is_empty_result: false,
         input_schema: None,
         base_query: None,
         base_query_result: None,
@@ -106,6 +110,7 @@ fn test_build_help_prompt_uses_output_sample() {
         error: None,
         json_type_info: JsonTypeInfo::default(),
         is_success: true,
+        is_empty_result: false,
         input_schema: None,
         base_query: None,
         base_query_result: None,
@@ -128,6 +133,7 @@ fn test_build_help_prompt_truncates_output_when_no_sample() {
         error: None,
         json_type_info: JsonTypeInfo::default(),
         is_success: true,
+        is_empty_result: false,
         input_schema: None,
         base_query: None,
         base_query_result: None,
@@ -148,6 +154,7 @@ fn test_build_success_prompt_includes_query() {
         error: None,
         json_type_info: JsonTypeInfo::default(),
         is_success: true,
+        is_empty_result: false,
         input_schema: None,
         base_query: None,
         base_query_result: None,
@@ -169,6 +176,7 @@ fn test_build_success_prompt_includes_output_sample() {
         error: None,
         json_type_info: JsonTypeInfo::default(),
         is_success: true,
+        is_empty_result: false,
         input_schema: None,
         base_query: None,
         base_query_result: None,
@@ -190,6 +198,7 @@ fn test_build_success_prompt_includes_schema() {
         error: None,
         json_type_info: JsonTypeInfo::default(),
         is_success: true,
+        is_empty_result: false,
         input_schema: Some(r#"["number"]"#.to_string()),
         base_query: None,
         base_query_result: None,
@@ -211,6 +220,7 @@ fn test_build_prompt_dispatches_to_error_prompt() {
         error: Some("syntax error".to_string()),
         json_type_info: JsonTypeInfo::default(),
         is_success: false,
+        is_empty_result: false,
         input_schema: None,
         base_query: None,
         base_query_result: None,
@@ -233,6 +243,7 @@ fn test_build_prompt_dispatches_to_success_prompt() {
         error: None,
         json_type_info: JsonTypeInfo::default(),
         is_success: true,
+        is_empty_result: false,
         input_schema: None,
         base_query: None,
         base_query_result: None,
@@ -255,6 +266,7 @@ fn test_build_error_prompt_includes_structured_format() {
         error: Some("error".to_string()),
         json_type_info: JsonTypeInfo::default(),
         is_success: false,
+        is_empty_result: false,
         input_schema: None,
         base_query: None,
         base_query_result: None,
@@ -278,6 +290,7 @@ fn test_build_success_prompt_includes_structured_format() {
         error: None,
         json_type_info: JsonTypeInfo::default(),
         is_success: true,
+        is_empty_result: false,
         input_schema: None,
         base_query: None,
         base_query_result: None,
@@ -300,6 +313,7 @@ fn test_build_prompt_includes_natural_language_instructions() {
         error: Some("error".to_string()),
         json_type_info: JsonTypeInfo::default(),
         is_success: false,
+        is_empty_result: false,
         input_schema: None,
         base_query: None,
         base_query_result: None,
@@ -321,6 +335,7 @@ fn test_error_prompt_includes_base_query() {
         error: Some("field not found".to_string()),
         json_type_info: JsonTypeInfo::default(),
         is_success: false,
+        is_empty_result: false,
         input_schema: None,
         base_query: Some(".name".to_string()),
         base_query_result: Some(r#""test""#.to_string()),
@@ -344,6 +359,7 @@ fn test_error_prompt_without_base_query() {
         error: Some("error".to_string()),
         json_type_info: JsonTypeInfo::default(),
         is_success: false,
+        is_empty_result: false,
         input_schema: None,
         base_query: None,
         base_query_result: None,
@@ -364,13 +380,14 @@ fn test_success_prompt_excludes_base_query() {
         error: None,
         json_type_info: JsonTypeInfo::default(),
         is_success: true,
+        is_empty_result: false,
         input_schema: None,
         base_query: Some(".old".to_string()), // Even if set
         base_query_result: Some("old result".to_string()),
     };
 
     let prompt = build_success_prompt(&ctx);
-    assert!(!prompt.contains("Last Working Query"));
+    assert!(!prompt.contains("Last Non-Empty Query"));
     assert!(!prompt.contains(".old"));
 }
 
@@ -389,6 +406,7 @@ fn test_base_query_result_truncation_in_context() {
             input_schema: None,
             base_query: Some(".base"),
             base_query_result: Some(&long_result),
+            is_empty_result: false,
         },
     );
 

--- a/src/app/app_events.rs
+++ b/src/app/app_events.rs
@@ -209,6 +209,7 @@ impl App {
                             .last_successful_result
                             .as_deref()
                             .map(|s| s.as_ref()),
+                        is_empty_result: query_state.is_empty_result,
                     },
                 );
             }

--- a/src/app/app_state.rs
+++ b/src/app/app_state.rs
@@ -220,6 +220,7 @@ impl App {
                     .last_successful_result
                     .as_deref()
                     .map(|s| s.as_ref()),
+                is_empty_result: query_state.is_empty_result,
             },
         );
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -600,6 +600,7 @@ fn test_handle_execution_result_does_not_change_visibility_on_error() {
             input_schema: None,
             base_query: None,
             base_query_result: None,
+            is_empty_result: false,
         },
     );
 
@@ -624,6 +625,7 @@ fn test_handle_execution_result_does_not_change_visibility_on_error() {
             input_schema: None,
             base_query: None,
             base_query_result: None,
+            is_empty_result: false,
         },
     );
 
@@ -659,6 +661,7 @@ fn test_handle_execution_result_does_not_change_visibility_on_success() {
             input_schema: None,
             base_query: None,
             base_query_result: None,
+            is_empty_result: false,
         },
     );
 
@@ -683,6 +686,7 @@ fn test_handle_execution_result_does_not_change_visibility_on_success() {
             input_schema: None,
             base_query: None,
             base_query_result: None,
+            is_empty_result: false,
         },
     );
 
@@ -762,6 +766,7 @@ fn test_visibility_control_mechanisms_complete() {
             input_schema: None,
             base_query: None,
             base_query_result: None,
+            is_empty_result: false,
         },
     );
     assert!(
@@ -781,6 +786,7 @@ fn test_visibility_control_mechanisms_complete() {
             input_schema: None,
             base_query: None,
             base_query_result: None,
+            is_empty_result: false,
         },
     );
     assert!(


### PR DESCRIPTION
## Summary
- Fix API error: "prompt is too long: 202297 tokens > 200000 maximum" when opening large CDK manifest.json files
- Root cause: `input_schema` field had no size limit while other fields were truncated to 25K chars
- Clean up AI context by removing redundant fields and adding missing context for empty results

## Changes

### Core Fixes
- **Truncate `input_schema`**: Apply same 25K character limit as other JSON fields
- **Remove `input_sample` from error prompts**: Schema alone is sufficient; actual JSON is redundant

### Context Enhancements
- **Add `cursor_pos` to success prompts**: Helps AI understand where user is editing
- **Add conditional `base_query`/`base_query_result` to success prompts**: When result is empty/null, include last working query for better AI suggestions
- **Add `is_empty_result` field**: Pass through entire context pipeline to enable conditional base_query inclusion

### Files Modified
- `src/ai/context.rs`: Added `is_empty_result` field, truncated `input_schema`
- `src/ai/prompt.rs`: Removed `input_sample` from error prompt, added `cursor_pos` and conditional base_query to success prompt
- `src/ai/ai_events.rs`: Changed success case to pass through all params
- `src/app/app_state.rs`, `src/app/app_events.rs`: Added `is_empty_result` to ContextParams
- Tests updated across all affected modules

## Test Plan
- ✅ All 1612 tests pass
- ✅ Release build succeeds with zero warnings
- ✅ Zero clippy warnings
- ✅ Formatting check passes