### PR TITLE
chore(deps): remove dirs crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,6 @@ serde = { version = "1.0", features = ["derive"] }
 # Find executables in PATH
 which = "6.0"
 
-# Cross-platform directory paths
-dirs = "5.0"
-
 # Clipboard support
 arboard = "3.4"
 base64 = "0.22"

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,7 +76,7 @@ pub fn load_config() -> ConfigResult {
 ///
 /// Always uses ~/.config/jiq/config.toml on all platforms for consistency.
 fn get_config_path() -> PathBuf {
-    dirs::home_dir()
+    std::env::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".config")
         .join("jiq")

--- a/src/history/storage.rs
+++ b/src/history/storage.rs
@@ -7,7 +7,36 @@ const HISTORY_DIR: &str = "jiq";
 const HISTORY_FILE: &str = "history";
 
 pub fn history_path() -> Option<PathBuf> {
-    dirs::data_dir().map(|p| p.join(HISTORY_DIR).join(HISTORY_FILE))
+    for supported_path in [
+        std::env::home_dir().map(|p| {
+            p.join(".local")
+                .join("share")
+                .join(HISTORY_DIR)
+                .join(HISTORY_FILE)
+        }),
+        // paths for backwards compatibility
+        #[cfg(target_os = "macos")]
+        std::env::home_dir().map(|p| {
+            p.join("Library/Application Support")
+                .join(HISTORY_DIR)
+                .join(HISTORY_FILE)
+        }),
+        #[cfg(target_os = "windows")]
+        std::env::home_dir().map(|p| {
+            p.join("AppData")
+                .join("Roaming")
+                .join(HISTORY_DIR)
+                .join(HISTORY_FILE)
+        }),
+    ]
+    .iter()
+    .filter_map(|v| v.as_ref())
+    {
+        if supported_path.exists() {
+            return Some(supported_path.clone());
+        }
+    }
+    None
 }
 
 pub fn load_history() -> Vec<String> {

--- a/src/snippets/snippet_storage.rs
+++ b/src/snippets/snippet_storage.rs
@@ -16,7 +16,7 @@ struct SnippetsFile {
 }
 
 pub fn snippets_path() -> Option<PathBuf> {
-    dirs::home_dir().map(|p| p.join(".config").join(CONFIG_DIR).join(SNIPPETS_FILE))
+    std::env::home_dir().map(|p| p.join(".config").join(CONFIG_DIR).join(SNIPPETS_FILE))
 }
 
 pub fn load_snippets() -> Vec<Snippet> {


### PR DESCRIPTION
I've removed the dirs crate and used the `std::env::home_dir()` to retrieve the user's home directory.

I have noticed that you didn't care about Windows when it came to the config and snippets paths. You basically hardcoded `.config` and `jiq`, so on Windows the config path looks as follows: `C:\Users\xxx\.config\jiq\config.toml`. I am not a Windows person, so I don't have a preference either way. I suspect that most people are using the Linux subsystem when using jiq on Windows anyway.
Thus I opted for the same method in this PR and just used the path components `.local` and `share` for the history path.

Please note that the "lengthy" `history_path` function is mostly the result of formatting (`cargo fmt`) and backwards compat. 

If correct Windows paths and following the `XDG` specs are wanted, I can always make use of the `etcetera` crate. However, since you used hardcoded paths on Windows, it will be extra work to maintain backwards compat on Windows. It's not a problem, I just wanted to mention it.

closes #151 