### PR TITLE
Add release-build debug logging via --debug flag or JIQ_DEBUG=1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ bytes = "1.5"
 aws-config = { version = "1", features = ["rustls"] }
 aws-sdk-bedrockruntime = { version = "1", features = ["rustls"] }
 
-# Logging (code only active in debug builds via #[cfg(debug_assertions)])
+# Logging (activated via --debug flag or JIQ_DEBUG=1 env var)
 log = "0.4"
 env_logger = "0.11"
 chrono = "0.4"

--- a/README.md
+++ b/README.md
@@ -467,6 +467,14 @@ profile = "default"  # Optional: AWS profile name (uses default credential chain
 - **Autocomplete** - Editing in the middle of a query falls back to root-level suggestions; for arrays, a configurable number of elements are sampled to build field suggestions (default: 10, configurable via `array_sample_size` in `[autocomplete]` config section).
 - **Syntax highlighting** - Basic keyword-based only, does not analyze structure like tree-sitter.
 
+## Troubleshooting
+
+When reporting a bug, re-run with debug logging and attach `/tmp/jiq-debug.log`:
+
+```bash
+jiq --debug data.json        # or: JIQ_DEBUG=1 jiq data.json
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on code architecture, testing, and pull requests.

--- a/src/ai/ai_events.rs
+++ b/src/ai/ai_events.rs
@@ -124,6 +124,7 @@ pub fn poll_response_channel(ai_state: &mut AiState) -> bool {
     }
 
     if disconnected && ai_state.loading {
+        log::error!("AI response channel disconnected while loading");
         ai_state.set_error("AI worker disconnected unexpectedly".to_string());
     }
 
@@ -151,6 +152,7 @@ pub fn handle_execution_result(
     let query_changed = ai_state.is_query_changed(query);
 
     if !query_changed {
+        log::debug!("AI: query unchanged, skipping request");
         return;
     }
 

--- a/src/ai/ai_state/response.rs
+++ b/src/ai/ai_state/response.rs
@@ -31,6 +31,7 @@ impl AiState {
     pub fn send_request(&mut self, prompt: String) -> bool {
         // Check if we have a channel first
         if self.request_tx.is_none() {
+            log::warn!("AI: no request channel, cannot send");
             return false;
         }
 
@@ -59,6 +60,7 @@ impl AiState {
             return true;
         }
         // If send failed, clear the token
+        log::error!("AI: request send failed (channel closed)");
         self.current_cancel_token = None;
         false
     }

--- a/src/ai/worker.rs
+++ b/src/ai/worker.rs
@@ -42,7 +42,12 @@ pub fn spawn_worker(
     response_tx: Sender<AiResponse>,
 ) {
     // Try to create the async provider from config
+    log::debug!("Initializing AI provider: {:?}", config.provider);
     let provider_result = AsyncAiProvider::from_config(config);
+    match &provider_result {
+        Ok(_) => log::debug!("AI provider initialized successfully"),
+        Err(e) => log::error!("AI provider initialization failed: {}", e),
+    }
 
     std::thread::spawn(move || {
         // Set a custom panic hook for this thread to suppress output
@@ -152,9 +157,12 @@ async fn handle_query_async(
 ) {
     // Check if already cancelled before starting
     if cancel_token.is_cancelled() {
+        log::debug!("AI request {} already cancelled", request_id);
         let _ = response_tx.send(AiResponse::Cancelled { request_id });
         return;
     }
+
+    log::debug!("AI request {}: prompt_len={}", request_id, prompt.len());
 
     // Check if provider is available
     let provider = match provider {
@@ -174,14 +182,15 @@ async fn handle_query_async(
         .await
     {
         Ok(()) => {
-            // Stream completed successfully
+            log::debug!("AI request {} completed", request_id);
             let _ = response_tx.send(AiResponse::Complete { request_id });
         }
         Err(AiError::Cancelled) => {
-            // Request was cancelled - send Cancelled response
+            log::debug!("AI request {} cancelled", request_id);
             let _ = response_tx.send(AiResponse::Cancelled { request_id });
         }
         Err(e) => {
+            log::error!("AI request {} failed: {}", request_id, e);
             let _ = response_tx.send(AiResponse::Error(e.to_string()));
         }
     }

--- a/src/app/app_state.rs
+++ b/src/app/app_state.rs
@@ -174,6 +174,7 @@ impl App {
             self.mark_dirty();
             match result {
                 Ok(json_input) => {
+                    log::debug!("File loaded successfully: {} bytes", json_input.len());
                     self.query = Some(QueryState::new_with_sample_size(
                         json_input.clone(),
                         self.array_sample_size,
@@ -200,7 +201,8 @@ impl App {
                         self.trigger_ai_request();
                     }
                 }
-                Err(_e) => {
+                Err(ref e) => {
+                    log::error!("File loader error: {:?}", e);
                     // Keep loader for state tracking
                     // Show brief notification - full error details in results area
                     self.notification.show_error("Failed to load file");

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -11,11 +11,19 @@ pub enum ClipboardError {
 }
 
 pub fn copy_to_clipboard(text: &str, backend: ClipboardBackend) -> ClipboardResult {
-    match backend {
+    log::debug!("Clipboard copy: backend={:?}, len={}", backend, text.len());
+    let result = match backend {
         ClipboardBackend::System => system::copy(text),
         ClipboardBackend::Osc52 => osc52::copy(text),
-        ClipboardBackend::Auto => system::copy(text).or_else(|_| osc52::copy(text)),
+        ClipboardBackend::Auto => system::copy(text).or_else(|_| {
+            log::debug!("System clipboard failed, falling back to OSC52");
+            osc52::copy(text)
+        }),
+    };
+    if let Err(ref e) = result {
+        log::warn!("Clipboard copy failed: {:?}", e);
     }
+    result
 }
 
 #[cfg(test)]

--- a/src/clipboard/clipboard_events.rs
+++ b/src/clipboard/clipboard_events.rs
@@ -27,6 +27,7 @@ fn copy_query(app: &mut App, backend: ClipboardBackend) -> bool {
     let query = app.query();
 
     if query.is_empty() {
+        log::debug!("Clipboard: query is empty, nothing to copy");
         return false;
     }
 
@@ -42,16 +43,23 @@ fn copy_result(app: &mut App, backend: ClipboardBackend) -> bool {
     // Only copy if query state is available
     let query_state = match &app.query {
         Some(q) => q,
-        None => return false,
+        None => {
+            log::debug!("Clipboard: no query state, nothing to copy");
+            return false;
+        }
     };
 
     // Copy what's displayed: last_successful_result_unformatted
     let full_result = match &query_state.last_successful_result_unformatted {
         Some(text) => text.as_ref().to_string(),
-        None => return false,
+        None => {
+            log::debug!("Clipboard: no result available to copy");
+            return false;
+        }
     };
 
     if full_result.is_empty() {
+        log::debug!("Clipboard: result is empty, nothing to copy");
         return false;
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,9 +29,11 @@ pub struct ConfigResult {
 /// Returns default configuration if file doesn't exist or on parse errors
 pub fn load_config() -> ConfigResult {
     let config_path = get_config_path();
+    log::debug!("Config path: {:?}", config_path);
 
     // If file doesn't exist, return defaults silently
     if !config_path.exists() {
+        log::debug!("No config file found, using defaults");
         return ConfigResult {
             config: Config::default(),
             warning: None,
@@ -42,7 +44,6 @@ pub fn load_config() -> ConfigResult {
     let contents = match fs::read_to_string(&config_path) {
         Ok(contents) => contents,
         Err(e) => {
-            #[cfg(debug_assertions)]
             log::error!("Failed to read config file {:?}: {}", config_path, e);
             return ConfigResult {
                 config: Config::default(),
@@ -56,13 +57,19 @@ pub fn load_config() -> ConfigResult {
         Ok(mut config) => {
             config.autocomplete.array_sample_size =
                 config.autocomplete.array_sample_size.clamp(1, 1000);
+            log::debug!(
+                "Config: clipboard={:?}, ai.enabled={}, ai.provider={:?}, array_sample_size={}",
+                config.clipboard.backend,
+                config.ai.enabled,
+                config.ai.provider,
+                config.autocomplete.array_sample_size
+            );
             ConfigResult {
                 config,
                 warning: None,
             }
         }
         Err(e) => {
-            #[cfg(debug_assertions)]
             log::error!("Failed to parse config file {:?}: {}", config_path, e);
             ConfigResult {
                 config: Config::default(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,7 @@ pub enum JiqError {
 
 impl From<std::io::Error> for JiqError {
     fn from(err: std::io::Error) -> Self {
+        log::error!("IO error: {}", err);
         JiqError::Io(err.to_string())
     }
 }

--- a/src/history/storage.rs
+++ b/src/history/storage.rs
@@ -11,6 +11,7 @@ pub fn history_path() -> Option<PathBuf> {
 }
 
 pub fn load_history() -> Vec<String> {
+    log::debug!("History path: {:?}", history_path());
     let Some(path) = history_path() else {
         return Vec::new();
     };
@@ -21,11 +22,13 @@ pub fn load_history() -> Vec<String> {
     };
 
     let reader = BufReader::new(file);
-    reader
+    let entries: Vec<String> = reader
         .lines()
         .map_while(Result::ok)
         .filter(|line| !line.trim().is_empty())
-        .collect()
+        .collect();
+    log::debug!("Loaded {} history entries", entries.len());
+    entries
 }
 
 pub fn save_history(entries: &[String]) -> io::Result<()> {
@@ -45,10 +48,11 @@ pub fn save_history(entries: &[String]) -> io::Result<()> {
     let unique_entries = deduplicate(entries);
     let trimmed = trim_to_max(&unique_entries);
 
-    for entry in trimmed {
+    for entry in &trimmed {
         writeln!(file, "{}", entry)?;
     }
 
+    log::debug!("Saved {} history entries", trimmed.len());
     Ok(())
 }
 

--- a/src/input/loader.rs
+++ b/src/input/loader.rs
@@ -80,6 +80,7 @@ impl FileLoader {
                 Err(std::sync::mpsc::TryRecvError::Empty) => None,
                 Err(std::sync::mpsc::TryRecvError::Disconnected) => {
                     self.rx = None;
+                    log::error!("File loader thread disconnected");
                     let err = JiqError::Io("File loader thread disconnected".to_string());
                     self.state = LoadingState::Error(err.clone());
                     Some(Err(err))
@@ -114,6 +115,7 @@ fn validate_json_or_jsonl(content: &str) -> Result<(), JiqError> {
     if count == 0 {
         return Err(JiqError::InvalidJson("Empty input".to_string()));
     }
+    log::debug!("JSON validation: {} top-level value(s)", count);
     Ok(())
 }
 
@@ -124,9 +126,11 @@ fn load_file_sync(path: &Path) -> Result<String, JiqError> {
     use std::fs::File;
     use std::io::Read;
 
+    log::debug!("Loading file: {:?}", path);
     let mut file = File::open(path)?;
     let mut contents = String::new();
     file.read_to_string(&mut contents)?;
+    log::debug!("File read: {} bytes", contents.len());
 
     validate_json_or_jsonl(&contents)?;
 
@@ -139,7 +143,9 @@ fn load_file_sync(path: &Path) -> Result<String, JiqError> {
 fn load_stdin_sync() -> Result<String, JiqError> {
     use std::io::{self, IsTerminal, Read};
 
+    log::debug!("Loading from stdin");
     if io::stdin().is_terminal() {
+        log::debug!("stdin is a terminal, no piped input");
         return Err(JiqError::Io(
             "No input provided. Usage: jiq <file> or echo '{}' | jiq".to_string(),
         ));
@@ -147,6 +153,7 @@ fn load_stdin_sync() -> Result<String, JiqError> {
 
     let mut buffer = String::new();
     io::stdin().read_to_string(&mut buffer)?;
+    log::debug!("Stdin read: {} bytes", buffer.len());
 
     validate_json_or_jsonl(&buffer)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,54 +52,33 @@ use query::executor::JqExecutor;
 struct Args {
     /// Input JSON file (if not provided, reads from stdin)
     input: Option<PathBuf>,
+
+    /// Enable debug logging to /tmp/jiq-debug.log
+    #[arg(long)]
+    debug: bool,
 }
 
 fn main() -> Result<()> {
-    // Writes to /tmp/jiq-debug.log at DEBUG level
-    #[cfg(debug_assertions)]
-    {
-        use std::io::Write;
+    let args = Args::parse();
 
-        let log_file = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open("/tmp/jiq-debug.log")
-            .expect("Failed to open /tmp/jiq-debug.log");
-
-        env_logger::Builder::new()
-            .filter_level(log::LevelFilter::Debug)
-            .target(env_logger::Target::Pipe(Box::new(log_file)))
-            .format(|buf, record| {
-                use std::time::SystemTime;
-                let datetime: chrono::DateTime<chrono::Local> = SystemTime::now().into();
-                writeln!(
-                    buf,
-                    "[{}] [{}] {}",
-                    datetime.format("%Y-%m-%dT%H:%M:%S%.3f"),
-                    record.level(),
-                    record.args()
-                )
-            })
-            .init();
-
-        log::debug!("=== JIQ DEBUG SESSION STARTED ===");
-    }
+    init_logger(args.debug);
 
     color_eyre::install()?;
 
     // Load config early to avoid defaults during app initialization
     let config_result = config::load_config();
 
-    let args = Args::parse();
-
     validate_jq_exists()?;
+    log::debug!("jq binary found in PATH");
 
     let terminal = init_terminal()?;
 
     // Deferred loading prevents blocking on large files/stdin
-    let loader = if let Some(path) = args.input {
-        FileLoader::spawn_load(path)
+    let loader = if let Some(ref path) = args.input {
+        log::debug!("File loader spawned for: {:?}", path);
+        FileLoader::spawn_load(path.clone())
     } else {
+        log::debug!("File loader spawned for stdin");
         FileLoader::spawn_load_stdin()
     };
 
@@ -112,7 +91,6 @@ fn main() -> Result<()> {
     // Output after terminal restore to prevent corruption
     handle_output(&app)?;
 
-    #[cfg(debug_assertions)]
     log::debug!("=== JIQ DEBUG SESSION ENDED ===");
 
     Ok(())
@@ -126,6 +104,7 @@ fn validate_jq_exists() -> Result<(), JiqError> {
 
 /// Initialize terminal with raw mode, alternate screen, and bracketed paste
 fn init_terminal() -> Result<DefaultTerminal> {
+    log::debug!("Initializing terminal");
     let hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         let _ = execute!(
@@ -139,6 +118,7 @@ fn init_terminal() -> Result<DefaultTerminal> {
     }));
 
     enable_raw_mode()?;
+    log::debug!("Raw mode enabled");
 
     // If any subsequent operations fail, ensure raw mode is disabled
     match execute!(
@@ -147,16 +127,23 @@ fn init_terminal() -> Result<DefaultTerminal> {
         EnableBracketedPaste,
         EnableMouseCapture
     ) {
-        Ok(_) => {}
+        Ok(_) => {
+            log::debug!("Alternate screen entered");
+        }
         Err(e) => {
+            log::error!("Failed to enter alternate screen: {}", e);
             let _ = disable_raw_mode();
             return Err(e.into());
         }
     }
 
     match ratatui::Terminal::new(ratatui::backend::CrosstermBackend::new(stdout())) {
-        Ok(terminal) => Ok(terminal),
+        Ok(terminal) => {
+            log::debug!("Terminal backend created");
+            Ok(terminal)
+        }
         Err(e) => {
+            log::error!("Failed to create terminal backend: {}", e);
             let _ = execute!(
                 stdout(),
                 DisableMouseCapture,
@@ -171,6 +158,7 @@ fn init_terminal() -> Result<DefaultTerminal> {
 
 /// Restore terminal to normal state
 fn restore_terminal() -> Result<()> {
+    log::debug!("Restoring terminal");
     let _ = execute!(
         stdout(),
         DisableMouseCapture,
@@ -219,6 +207,11 @@ fn run(
 
 /// Set up the AI worker thread and channels
 fn setup_ai_worker(app: &mut App, config: &config::Config) {
+    log::debug!(
+        "AI setup: enabled={}, configured={}",
+        config.ai.enabled,
+        app.ai.configured
+    );
     if config.ai.enabled && !app.ai.configured {
         app.notification
             .show_warning("AI enabled but not configured. Add provider credentials to config.");
@@ -226,6 +219,7 @@ fn setup_ai_worker(app: &mut App, config: &config::Config) {
 
     // Worker needed even when disabled to support Ctrl+A toggle
     if !app.ai.configured {
+        log::debug!("AI: skipping worker spawn (not configured)");
         return;
     }
 
@@ -235,6 +229,65 @@ fn setup_ai_worker(app: &mut App, config: &config::Config) {
 
     // Spawn the worker thread
     ai::worker::spawn_worker(&config.ai, request_rx, response_tx);
+    log::debug!("AI worker spawned");
+}
+
+/// Initialize debug logger when activated via --debug flag, JIQ_DEBUG=1, or debug build.
+/// All output goes to /tmp/jiq-debug.log (never stdout/stderr).
+fn init_logger(cli_debug: bool) {
+    let env_debug = std::env::var("JIQ_DEBUG").is_ok_and(|v| v == "1");
+    let debug_build = cfg!(debug_assertions);
+    let enabled = cli_debug || env_debug || debug_build;
+
+    if !enabled {
+        return;
+    }
+
+    use std::io::Write;
+
+    let log_file = match std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("/tmp/jiq-debug.log")
+    {
+        Ok(f) => f,
+        Err(_) => return,
+    };
+
+    env_logger::Builder::new()
+        .filter_level(log::LevelFilter::Debug)
+        .target(env_logger::Target::Pipe(Box::new(log_file)))
+        .format(|buf, record| {
+            use std::time::SystemTime;
+            let datetime: chrono::DateTime<chrono::Local> = SystemTime::now().into();
+            writeln!(
+                buf,
+                "[{}] [{}] {}",
+                datetime.format("%Y-%m-%dT%H:%M:%S%.3f"),
+                record.level(),
+                record.args()
+            )
+        })
+        .init();
+
+    let method = match (cli_debug, env_debug, debug_build) {
+        (true, true, _) => "--debug flag and JIQ_DEBUG env var",
+        (true, false, _) => "--debug flag",
+        (false, true, _) => "JIQ_DEBUG env var",
+        (false, false, true) => "debug build",
+        _ => "unknown",
+    };
+
+    log::debug!(
+        "=== JIQ DEBUG SESSION STARTED (v{}) ===",
+        env!("CARGO_PKG_VERSION")
+    );
+    log::debug!("Activated via: {}", method);
+    log::debug!(
+        "Platform: {} {}",
+        std::env::consts::OS,
+        std::env::consts::ARCH
+    );
 }
 
 /// Handle output after terminal is restored

--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -122,6 +122,11 @@ impl JqExecutor {
 
         // Empty query defaults to identity filter
         let query = if query.trim().is_empty() { "." } else { query };
+        log::debug!(
+            "jq query: {:?} (input: {} bytes)",
+            query,
+            self.json_input.len()
+        );
 
         // Galaxy theme colors for jq output (using true color ANSI codes)
         // Format: null:false:true:numbers:strings:arrays:objects:keys
@@ -185,11 +190,20 @@ impl JqExecutor {
 
         // Poll for completion or cancellation
         const POLL_INTERVAL_MS: u64 = 10;
+        let poll_start = std::time::Instant::now();
+        let mut slow_warned = false;
         let status = loop {
             // Check cancellation first
             if cancel_token.is_cancelled() {
+                log::debug!("jq process killed due to cancellation");
                 let _ = child.kill();
                 return Err(QueryError::Cancelled);
+            }
+
+            // Warn once if jq is taking a long time
+            if !slow_warned && poll_start.elapsed() > Duration::from_secs(5) {
+                log::warn!("jq process still running after 5s for query {:?}", query);
+                slow_warned = true;
             }
 
             // Check if process finished
@@ -214,11 +228,12 @@ impl JqExecutor {
             .map_err(|_| QueryError::OutputReadFailed("Failed to read stderr".to_string()))?;
 
         if status.success() {
+            log::debug!("jq succeeded: {} bytes output", stdout_data.len());
             Ok(String::from_utf8_lossy(&stdout_data).to_string())
         } else {
-            Err(QueryError::ExecutionFailed(
-                String::from_utf8_lossy(&stderr_data).to_string(),
-            ))
+            let stderr_str = String::from_utf8_lossy(&stderr_data).to_string();
+            log::debug!("jq failed (exit {:?}): {}", status.code(), stderr_str);
+            Err(QueryError::ExecutionFailed(stderr_str))
         }
     }
 }

--- a/src/query/query_state.rs
+++ b/src/query/query_state.rs
@@ -272,10 +272,17 @@ impl QueryState {
     /// Automatically cancels any in-flight request before starting new one.
     pub fn execute_async(&mut self, query: &str) {
         // Cancel any existing request
+        let had_in_flight = self.in_flight_request_id.is_some();
         self.cancel_in_flight();
 
         // Allocate new request ID
         let request_id = self.next_request_id;
+        log::debug!(
+            "execute_async: query={:?}, request_id={}, cancelling_previous={}",
+            query,
+            request_id,
+            had_in_flight
+        );
         self.next_request_id = self.next_request_id.wrapping_add(1);
 
         // Skip 0 on wrap (reserved for worker errors)
@@ -374,6 +381,11 @@ impl QueryState {
             } => {
                 // Ignore stale responses
                 if Some(request_id) != current_request_id {
+                    log::debug!(
+                        "Discarding stale query response {} (current: {:?})",
+                        request_id,
+                        current_request_id
+                    );
                     return None;
                 }
 

--- a/src/query/worker/thread.rs
+++ b/src/query/worker/thread.rs
@@ -106,6 +106,7 @@ fn handle_request(
 ) {
     // Check if already cancelled
     if request.cancel_token.is_cancelled() {
+        log::debug!("Query {} already cancelled", request.request_id);
         let _ = response_tx.send(QueryResponse::Cancelled {
             request_id: request.request_id,
         });
@@ -115,13 +116,16 @@ fn handle_request(
     // Execute query with cancellation support
     let query = request.query.clone();
     let start = Instant::now();
+    log::debug!("Query {}: {:?}", request.request_id, query);
 
     match executor.execute_with_cancel(&request.query, &request.cancel_token) {
         Ok(output) => {
             // Preprocess result (expensive operations done in worker thread)
             match preprocess_result(output, &query, &request.cancel_token, array_sample_size) {
                 Ok(mut processed) => {
-                    processed.execution_time_ms = Some(start.elapsed().as_millis() as u64);
+                    let elapsed = start.elapsed();
+                    processed.execution_time_ms = Some(elapsed.as_millis() as u64);
+                    log::debug!("Query {} completed in {:?}", request.request_id, elapsed);
                     let _ = response_tx.send(QueryResponse::ProcessedSuccess {
                         processed,
                         request_id: request.request_id,
@@ -147,6 +151,12 @@ fn handle_request(
             });
         }
         Err(e) => {
+            log::debug!(
+                "Query {} failed in {:?}: {}",
+                request.request_id,
+                start.elapsed(),
+                e
+            );
             let _ = response_tx.send(QueryResponse::Error {
                 message: e.to_string(),
                 query: request.query,

--- a/src/snippets/snippet_storage.rs
+++ b/src/snippets/snippet_storage.rs
@@ -20,6 +20,7 @@ pub fn snippets_path() -> Option<PathBuf> {
 }
 
 pub fn load_snippets() -> Vec<Snippet> {
+    log::debug!("Snippets path: {:?}", snippets_path());
     let Some(path) = snippets_path() else {
         return Vec::new();
     };
@@ -30,7 +31,10 @@ pub fn load_snippets() -> Vec<Snippet> {
 pub fn load_snippets_from_path(path: &PathBuf) -> Vec<Snippet> {
     let mut file = match File::open(path) {
         Ok(f) => f,
-        Err(_) => return Vec::new(),
+        Err(_) => {
+            log::debug!("No snippets file at {:?}", path);
+            return Vec::new();
+        }
     };
 
     let mut contents = String::new();
@@ -44,7 +48,10 @@ pub fn load_snippets_from_path(path: &PathBuf) -> Vec<Snippet> {
 pub fn parse_snippets_toml(content: &str) -> Vec<Snippet> {
     match toml::from_str::<SnippetsFile>(content) {
         Ok(snippets_file) => snippets_file.snippets,
-        Err(_) => Vec::new(),
+        Err(e) => {
+            log::warn!("Failed to parse snippets TOML: {}", e);
+            Vec::new()
+        }
     }
 }
 
@@ -64,6 +71,7 @@ pub fn save_snippets(snippets: &[Snippet]) -> io::Result<()> {
     let mut file = File::create(&path)?;
     file.write_all(content.as_bytes())?;
 
+    log::debug!("Saved {} snippets", snippets.len());
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- End users running release binaries can now enable debug logging via `--debug` or `JIQ_DEBUG=1`; logs go to `/tmp/jiq-debug.log` at DEBUG level with zero overhead when disabled
- Expanded log coverage across session lifecycle, config, file I/O, jq execution, query dispatch, AI requests, clipboard, and terminal init so logs carry enough context to diagnose real issues
- Added concise Troubleshooting section to README

## Test plan
- [x] `cargo build --release` — zero warnings
- [x] `cargo test` — all 2986 tests pass
- [x] `cargo clippy --all-targets --all-features` — zero warnings
- [x] `cargo fmt --all --check` — clean
- [x] `jiq --debug <file>` produces log at `/tmp/jiq-debug.log` with `Activated via: --debug flag`
- [x] `JIQ_DEBUG=1 jiq <file>` produces log with `Activated via: JIQ_DEBUG env var`
- [x] `jiq <file>` (no flag) produces no log file — zero overhead path
- [x] Invalid JSON input surfaces `File loader error: InvalidJson(...)` with parse location
- [x] jq syntax errors logged with full stderr (line/column)
- [x] Clipboard early returns logged (e.g., empty query/result)
- [x] Config values (clipboard backend, AI provider, array_sample_size) visible in logs
- [x] Terminal init phases logged (raw mode → alt screen → backend created)
- [x] All logs go to file only — no stdout/stderr pollution (TUI-safe)