### PR TITLE
fix(ai): truncate json context at UTF-8 boundaries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ if clipboard::handle_clipboard_key(self, key) {
 
 ```bash
 cargo build              # Zero warnings required
-cargo clippy -D warnings # Must pass
+cargo clippy -- -D warnings  # Must pass
 ```
 
 **DRY Principles:**

--- a/src/ai/context.rs
+++ b/src/ai/context.rs
@@ -115,8 +115,9 @@ pub fn truncate_json(json: &str, max_len: usize) -> String {
         return json.to_string();
     }
 
-    // Simple truncation with ellipsis indicator
-    let truncated = &json[..max_len];
+    // Truncate on UTF-8 character boundary with ellipsis indicator
+    let end = json.floor_char_boundary(max_len);
+    let truncated = &json[..end];
     format!("{}... [truncated]", truncated)
 }
 

--- a/src/ai/context_tests.rs
+++ b/src/ai/context_tests.rs
@@ -34,6 +34,21 @@ fn test_truncate_json_long() {
 }
 
 #[test]
+fn test_truncate_json_does_not_panic_mid_utf8_char() {
+    // Byte index `max_len` falls inside U+7AE0 '章' (UTF-8: 3 bytes) without adjustment.
+    let prefix_len = 99_999;
+    let json = format!("{}{}", "x".repeat(prefix_len), "章".repeat(500));
+    assert!(json.len() > prefix_len + 1);
+    assert!(!json.is_char_boundary(prefix_len + 1));
+
+    let truncated = truncate_json(&json, prefix_len + 1);
+    assert!(truncated.ends_with("... [truncated]"));
+    let body = truncated.trim_end_matches("... [truncated]");
+    assert!(json.starts_with(body));
+    assert!(body.len() <= prefix_len + 1);
+}
+
+#[test]
 fn test_query_context_new() {
     let query = ".name".to_string();
     let ctx = QueryContext::new(


### PR DESCRIPTION
## Summary

- Fix a panic when loading a large json with UTF-8 chars.
- truncate_json` sliced with a raw byte index (`[..max_len]`), so the cut could land inside a multibyte UTF-8 sequence.
- Truncate using `str::floor_char_boundary(max_len)` before slicing so the prefix stays valid `str`.
- Add a regression test that would have panicked before the fix.

## Panic Example
```sh
The application panicked (crashed).
Message:  byte index 100000 is not a char boundary; it is inside '章' (bytes 99999..100002) of `[{"avg_response_len":1263.25,"entropy":3.75,"longest_response":"Coffee稣.Frame ...`[...]
Location: src/ai/context.rs:119
```