### PR TITLE
Fix clippy lints surfaced by Rust 1.95.0 (unblocks #158)

### DIFF
--- a/src/history/matcher.rs
+++ b/src/history/matcher.rs
@@ -53,7 +53,7 @@ impl HistoryMatcher {
             })
             .collect();
 
-        scored.sort_by(|a, b| b.1.cmp(&a.1));
+        scored.sort_by_key(|entry| std::cmp::Reverse(entry.1));
 
         scored.into_iter().map(|(idx, _)| idx).collect()
     }

--- a/src/results/results_render.rs
+++ b/src/results/results_render.rs
@@ -50,11 +50,7 @@ fn format_position_indicator(scroll: &ScrollState, line_count: u32) -> String {
     }
     let start = scroll.offset as u32 + 1;
     let end = (scroll.offset as u32 + scroll.viewport_height as u32).min(line_count);
-    let percentage = if line_count > 0 {
-        (scroll.offset as u32 * 100) / line_count
-    } else {
-        0
-    };
+    let percentage = (scroll.offset as u32 * 100) / line_count;
     format!("L{}-{}/{} ({}%)", start, end, line_count, percentage)
 }
 

--- a/src/snippets/snippet_matcher.rs
+++ b/src/snippets/snippet_matcher.rs
@@ -53,7 +53,7 @@ impl SnippetMatcher {
             })
             .collect();
 
-        scored.sort_by(|a, b| b.1.cmp(&a.1));
+        scored.sort_by_key(|entry| std::cmp::Reverse(entry.1));
 
         scored.into_iter().map(|(idx, _)| idx).collect()
     }

--- a/src/stats/parser.rs
+++ b/src/stats/parser.rs
@@ -76,10 +76,8 @@ impl StatsParser {
                 ']' | '}' => {
                     depth -= 1;
                 }
-                ',' => {
-                    if depth == 1 {
-                        comma_count += 1;
-                    }
+                ',' if depth == 1 => {
+                    comma_count += 1;
                 }
                 c if !c.is_whitespace() && depth == 1 => {
                     has_content = true;

--- a/src/tooltip/detector.rs
+++ b/src/tooltip/detector.rs
@@ -240,11 +240,8 @@ fn check_triple_slash_equals(chars: &[char], cursor_pos: usize) -> Option<&'stat
                 return Some("//=");
             }
         }
-        '=' => {
-            // Check if this is the = of //=
-            if cursor_pos >= 2 && chars[cursor_pos - 1] == '/' && chars[cursor_pos - 2] == '/' {
-                return Some("//=");
-            }
+        '=' if cursor_pos >= 2 && chars[cursor_pos - 1] == '/' && chars[cursor_pos - 2] == '/' => {
+            return Some("//=");
         }
         _ => {}
     }
@@ -284,17 +281,11 @@ fn check_pipe_equals(chars: &[char], cursor_pos: usize) -> Option<&'static str> 
     let current = chars[cursor_pos];
 
     match current {
-        '|' => {
-            // Check if | is followed by =
-            if cursor_pos + 1 < len && chars[cursor_pos + 1] == '=' {
-                return Some("|=");
-            }
+        '|' if cursor_pos + 1 < len && chars[cursor_pos + 1] == '=' => {
+            return Some("|=");
         }
-        '=' => {
-            // Check if = is preceded by |
-            if cursor_pos > 0 && chars[cursor_pos - 1] == '|' {
-                return Some("|=");
-            }
+        '=' if cursor_pos > 0 && chars[cursor_pos - 1] == '|' => {
+            return Some("|=");
         }
         _ => {}
     }


### PR DESCRIPTION
## Summary

Fixes 7 clippy errors that surfaced when CI's `dtolnay/rust-toolchain@stable` rolled forward to Rust 1.95.0. All hits are in pre-existing code; none of them were introduced by recent changes.

- `unnecessary_sort_by` in `src/history/matcher.rs` and `src/snippets/snippet_matcher.rs` — switched to `sort_by_key(|entry| Reverse(entry.1))`
- `manual_checked_ops` (new in 1.95) in `src/results/results_render.rs` — removed redundant `if line_count > 0` guard; the function already returns early on `line_count == 0`, so the check was dead code
- `collapsible_match` in `src/stats/parser.rs` and `src/tooltip/detector.rs` (3 sites) — folded inner `if` into match guards

All changes are behavior-preserving refactors.

## Why now

PR #158 (UTF-8 truncation fix) is currently red on `Lint` for these same 7 errors despite the PR not touching any of the affected files. Merging this PR and then updating #158's branch will let CI go green there.

## Test plan

Verified locally against the exact toolchain CI uses (Rust 1.95.0):

- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build --release` — clean, zero warnings
- [x] `cargo test --all-features --lib -- --test-threads=1` — 2986 passed / 0 failed
- [x] `cargo test --all-features -- --test-threads=1` (integration + doctests) — 19 + 4 passed / 0 failed


---
_Generated by [Claude Code](https://claude.ai/code/session_01JY93cXmBhRoBVJw2Q7AawQ)_