### PR TITLE
fix(search): reset viewport, dim results, show "No Matches" badge on no-match

### DIFF
--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__search_tests__snapshot_search_bar_no_matches.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__search_tests__snapshot_search_bar_no_matches.snap
@@ -1,8 +1,9 @@
 ---
 source: src/app/app_render_tests/search_tests.rs
+assertion_line: 81
 expression: output
 ---
-"╭ Object ───────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
+"╭   ⚠ No Matches    Object ─────────────────────────────────────── L1-4/4 (0%) ╮"
 "▌{                                                                             │"
 "│  "name": "Alice",                                                            │"
 "│  "age": 30                                                                   │"

--- a/src/results/results_render.rs
+++ b/src/results/results_render.rs
@@ -267,7 +267,23 @@ pub fn render_pane(app: &mut App, frame: &mut Frame, area: Rect) -> (Rect, Optio
         unfocused_border_color
     };
 
-    let is_stale = query_state.result.is_err() || query_state.is_empty_result;
+    let search_no_match = search_visible
+        && !app.search.is_confirmed()
+        && !app.search.query().is_empty()
+        && app.search.matches().is_empty();
+    let is_stale = query_state.result.is_err() || query_state.is_empty_result || search_no_match;
+
+    let title = if search_no_match {
+        let mut spans = vec![
+            Span::raw(" "),
+            Span::styled("  ⚠ No Matches  ", theme::search::BADGE_NO_MATCHES),
+            Span::raw(" "),
+        ];
+        spans.extend(title.spans);
+        Line::from(spans)
+    } else {
+        title
+    };
 
     // Always render from cached pre-rendered text
     if let Some(rendered) = &query_state.last_successful_result_rendered {

--- a/src/results/results_render_tests.rs
+++ b/src/results/results_render_tests.rs
@@ -4,6 +4,7 @@ use crate::input::FileLoader;
 use proptest::prelude::*;
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
+use ratatui::style::Modifier;
 use std::path::PathBuf;
 
 /// Helper to create a test terminal
@@ -516,5 +517,189 @@ mod scrollbar_tests {
             has_scrollbar_in_middle,
             "Scrollbar should render between the corners"
         );
+    }
+}
+
+#[cfg(test)]
+mod search_no_match_dim_tests {
+    use super::*;
+    use crate::search::search_events::open_search;
+    use crate::test_utils::test_helpers::test_app;
+    use std::sync::Arc;
+
+    fn setup_app_with_results(content: &str) -> App {
+        use ratatui::text::Text;
+
+        let mut app = test_app(r#"{"name": "test"}"#);
+        let arc = Arc::new(content.to_string());
+        let q = app.query.as_mut().unwrap();
+        q.last_successful_result = Some(Arc::clone(&arc));
+        q.last_successful_result_unformatted = Some(Arc::clone(&arc));
+        q.last_successful_result_rendered = Some(Text::raw(content.to_string()));
+        q.result = Ok(content.to_string());
+        q.is_empty_result = false;
+        app
+    }
+
+    fn count_dim_cells(app: &mut App, width: u16, height: u16) -> (usize, usize) {
+        use crate::search::search_render::SEARCH_BAR_HEIGHT;
+
+        let mut terminal = create_test_terminal(width, height);
+        terminal.draw(|f| app.render(f)).unwrap();
+        let buffer = terminal.backend().buffer();
+
+        // Scan only the interior viewport of the results pane: skip top/bottom
+        // borders, the search bar, and the bottom-border row that may carry
+        // overlaid hint text (which uses DIM styling unrelated to is_stale).
+        let results_bottom = height.saturating_sub(SEARCH_BAR_HEIGHT);
+        let scan_y_start: u16 = 1;
+        let scan_y_end: u16 = results_bottom.saturating_sub(2);
+        let scan_x_start: u16 = 1;
+        let scan_x_end: u16 = width.saturating_sub(1);
+
+        let mut dim = 0usize;
+        let mut content = 0usize;
+        for y in scan_y_start..scan_y_end {
+            for x in scan_x_start..scan_x_end {
+                let cell = &buffer[(x, y)];
+                let sym = cell.symbol();
+                if sym.trim().is_empty() {
+                    continue;
+                }
+                if matches!(sym, "│" | "─" | "╭" | "╮" | "╰" | "╯" | "█") {
+                    continue;
+                }
+                content += 1;
+                if cell.modifier.contains(Modifier::DIM) {
+                    dim += 1;
+                }
+            }
+        }
+        (dim, content)
+    }
+
+    #[test]
+    fn no_dim_when_search_query_has_matches() {
+        let content = "alpha line\nbeta line\nalpha again\n";
+        let mut app = setup_app_with_results(content);
+
+        open_search(&mut app);
+        app.search.search_textarea_mut().insert_str("alpha");
+        app.search.update_matches(content);
+
+        let (dim, total) = count_dim_cells(&mut app, 60, 12);
+        assert!(total > 0, "should have rendered content cells");
+        assert_eq!(dim, 0, "no cells should be dimmed when matches exist");
+    }
+
+    #[test]
+    fn dim_when_search_query_has_no_matches() {
+        let content = "alpha line\nbeta line\nalpha again\n";
+        let mut app = setup_app_with_results(content);
+
+        open_search(&mut app);
+        app.search.search_textarea_mut().insert_str("zzz");
+        app.search.update_matches(content);
+
+        let (dim, total) = count_dim_cells(&mut app, 60, 12);
+        assert!(total > 0, "should have rendered content cells");
+        assert!(dim > 0, "result cells should be dimmed when no matches");
+    }
+
+    #[test]
+    fn no_dim_when_search_query_is_empty() {
+        let content = "alpha line\nbeta line\nalpha again\n";
+        let mut app = setup_app_with_results(content);
+
+        open_search(&mut app);
+
+        let (dim, total) = count_dim_cells(&mut app, 60, 12);
+        assert!(total > 0, "should have rendered content cells");
+        assert_eq!(dim, 0, "empty query must not dim");
+    }
+
+    fn render_to_string_local(app: &mut App, width: u16, height: u16) -> String {
+        let mut terminal = create_test_terminal(width, height);
+        terminal.draw(|f| app.render(f)).unwrap();
+        terminal.backend().to_string()
+    }
+
+    #[test]
+    fn shows_no_matches_badge_when_search_query_has_no_matches() {
+        let content = "alpha line\nbeta line\n";
+        let mut app = setup_app_with_results(content);
+
+        open_search(&mut app);
+        app.search.search_textarea_mut().insert_str("zzz");
+        app.search.update_matches(content);
+
+        let output = render_to_string_local(&mut app, 60, 12);
+        assert!(
+            output.contains("No Matches"),
+            "results pane title should advertise the no-match state. Output:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn no_no_matches_badge_when_query_has_matches() {
+        let content = "alpha line\nbeta line\n";
+        let mut app = setup_app_with_results(content);
+
+        open_search(&mut app);
+        app.search.search_textarea_mut().insert_str("alpha");
+        app.search.update_matches(content);
+
+        let output = render_to_string_local(&mut app, 60, 12);
+        assert!(
+            !output.contains("No Matches"),
+            "title must not show no-match badge while matches exist"
+        );
+    }
+
+    #[test]
+    fn no_no_matches_badge_when_query_is_empty() {
+        let content = "alpha line\nbeta line\n";
+        let mut app = setup_app_with_results(content);
+
+        open_search(&mut app);
+
+        let output = render_to_string_local(&mut app, 60, 12);
+        assert!(
+            !output.contains("No Matches"),
+            "title must not show no-match badge while query is empty"
+        );
+    }
+
+    #[test]
+    fn no_no_matches_badge_when_confirmed() {
+        let content = "alpha line\nbeta line\n";
+        let mut app = setup_app_with_results(content);
+
+        open_search(&mut app);
+        app.search.search_textarea_mut().insert_str("zzz");
+        app.search.update_matches(content);
+        app.search.confirm();
+
+        let output = render_to_string_local(&mut app, 60, 12);
+        assert!(
+            !output.contains("No Matches"),
+            "confirmed mode must not show the no-match badge"
+        );
+    }
+
+    #[test]
+    fn no_dim_when_search_confirmed_with_no_matches() {
+        let content = "alpha line\nbeta line\n";
+        let mut app = setup_app_with_results(content);
+
+        open_search(&mut app);
+        app.search.search_textarea_mut().insert_str("zzz");
+        app.search.update_matches(content);
+        app.search.confirm();
+
+        let (dim, total) = count_dim_cells(&mut app, 60, 12);
+        assert!(total > 0, "should have rendered content cells");
+        assert_eq!(dim, 0, "confirmed mode must not dim, even with no matches");
     }
 }

--- a/src/search/search_events.rs
+++ b/src/search/search_events.rs
@@ -116,6 +116,9 @@ pub fn handle_search_key(app: &mut App, key: KeyEvent) -> bool {
 
             if let Some(m) = app.search.current_match() {
                 scroll_to_line(app, m.line);
+            } else if !app.search.query().is_empty() {
+                app.results_scroll.offset = 0;
+                app.results_scroll.h_offset = 0;
             }
 
             true

--- a/src/search/search_events_tests.rs
+++ b/src/search/search_events_tests.rs
@@ -2,5 +2,7 @@
 mod lifecycle_tests;
 #[path = "search_events_tests/navigation_tests.rs"]
 mod navigation_tests;
+#[path = "search_events_tests/no_match_tests.rs"]
+mod no_match_tests;
 #[path = "search_events_tests/scroll_tests.rs"]
 mod scroll_tests;

--- a/src/search/search_events_tests/no_match_tests.rs
+++ b/src/search/search_events_tests/no_match_tests.rs
@@ -1,0 +1,153 @@
+use super::super::*;
+use crate::test_utils::test_helpers::{key, test_app};
+use std::sync::Arc;
+
+fn setup_app_with_matchable_content(query_state_content: &str) -> crate::app::App {
+    let mut app = test_app(r#"{"name": "test"}"#);
+    app.query.as_mut().unwrap().last_successful_result =
+        Some(Arc::new(query_state_content.to_string()));
+    app.query
+        .as_mut()
+        .unwrap()
+        .last_successful_result_unformatted = Some(Arc::new(query_state_content.to_string()));
+
+    app.results_scroll.viewport_height = 10;
+    app.results_scroll.max_offset = 100;
+    app.results_scroll.max_h_offset = 100;
+    open_search(&mut app);
+    app
+}
+
+#[test]
+fn test_typing_no_match_resets_scroll_to_top() {
+    let content: String = (0..50)
+        .map(|i| {
+            if i == 30 {
+                "match line\n".to_string()
+            } else {
+                format!("other {}\n", i)
+            }
+        })
+        .collect();
+    let mut app = setup_app_with_matchable_content(&content);
+
+    handle_search_key(&mut app, key(KeyCode::Char('m')));
+    handle_search_key(&mut app, key(KeyCode::Char('a')));
+    handle_search_key(&mut app, key(KeyCode::Char('t')));
+    handle_search_key(&mut app, key(KeyCode::Char('c')));
+    handle_search_key(&mut app, key(KeyCode::Char('h')));
+
+    assert_eq!(app.search.matches().len(), 1);
+    assert!(
+        app.results_scroll.offset > 0,
+        "viewport should have scrolled to the match"
+    );
+
+    handle_search_key(&mut app, key(KeyCode::Char('z')));
+
+    assert_eq!(app.search.query(), "matchz");
+    assert!(app.search.matches().is_empty());
+    assert_eq!(
+        app.results_scroll.offset, 0,
+        "offset should reset to 0 on no-match"
+    );
+    assert_eq!(
+        app.results_scroll.h_offset, 0,
+        "h_offset should reset to 0 on no-match"
+    );
+}
+
+#[test]
+fn test_typing_no_match_resets_horizontal_scroll() {
+    let content = format!("{}match\n", " ".repeat(150));
+    let mut app = setup_app_with_matchable_content(&content);
+
+    handle_search_key(&mut app, key(KeyCode::Char('m')));
+    handle_search_key(&mut app, key(KeyCode::Char('a')));
+    handle_search_key(&mut app, key(KeyCode::Char('t')));
+    handle_search_key(&mut app, key(KeyCode::Char('c')));
+    handle_search_key(&mut app, key(KeyCode::Char('h')));
+
+    assert!(
+        app.results_scroll.h_offset > 0,
+        "should have scrolled horizontally to the match"
+    );
+
+    handle_search_key(&mut app, key(KeyCode::Char('z')));
+
+    assert!(app.search.matches().is_empty());
+    assert_eq!(app.results_scroll.h_offset, 0);
+    assert_eq!(app.results_scroll.offset, 0);
+}
+
+#[test]
+fn test_backspace_to_match_restores_scroll_to_match() {
+    let content: String = (0..50)
+        .map(|i| {
+            if i == 30 {
+                "match line\n".to_string()
+            } else {
+                format!("other {}\n", i)
+            }
+        })
+        .collect();
+    let mut app = setup_app_with_matchable_content(&content);
+
+    handle_search_key(&mut app, key(KeyCode::Char('m')));
+    handle_search_key(&mut app, key(KeyCode::Char('a')));
+    handle_search_key(&mut app, key(KeyCode::Char('t')));
+    handle_search_key(&mut app, key(KeyCode::Char('c')));
+    handle_search_key(&mut app, key(KeyCode::Char('h')));
+    handle_search_key(&mut app, key(KeyCode::Char('z')));
+
+    assert!(app.search.matches().is_empty());
+    assert_eq!(app.results_scroll.offset, 0);
+
+    handle_search_key(&mut app, key(KeyCode::Backspace));
+
+    assert_eq!(app.search.query(), "match");
+    assert_eq!(app.search.matches().len(), 1);
+    assert!(
+        app.results_scroll.offset > 0,
+        "scroll should re-target the match after backspace"
+    );
+}
+
+#[test]
+fn test_backspace_to_empty_query_does_not_reset_scroll() {
+    let content: String = (0..50)
+        .map(|i| {
+            if i == 30 {
+                "match line\n".to_string()
+            } else {
+                format!("other {}\n", i)
+            }
+        })
+        .collect();
+    let mut app = setup_app_with_matchable_content(&content);
+
+    app.results_scroll.offset = 25;
+    app.results_scroll.h_offset = 7;
+
+    handle_search_key(&mut app, key(KeyCode::Char('z')));
+    assert!(app.search.matches().is_empty());
+    assert_eq!(
+        app.results_scroll.offset, 0,
+        "no-match while typing should reset"
+    );
+
+    app.results_scroll.offset = 25;
+    app.results_scroll.h_offset = 7;
+
+    handle_search_key(&mut app, key(KeyCode::Backspace));
+
+    assert!(app.search.query().is_empty());
+    assert_eq!(
+        app.results_scroll.offset, 25,
+        "empty-query path must not reset offset"
+    );
+    assert_eq!(
+        app.results_scroll.h_offset, 7,
+        "empty-query path must not reset h_offset"
+    );
+}


### PR DESCRIPTION
## Summary
- When typing in the search bar (Ctrl+F edit mode) and the query yields zero matches, the results pane now: (1) resets scroll to the top (offset and h_offset both 0), (2) dims the rendered results (`Modifier::DIM`, same as syntax-error / no-results states), and (3) shows a red `⚠ No Matches` badge prepended to the results pane title — visually consistent with the existing `⚠ Syntax Error` and `∅ No Results` badges.
- All three behaviors apply only while typing (not in confirmed mode after Enter), and only when the query is non-empty (an empty query is the fresh-search-bar state).

## Test plan
- [x] Added 4 unit tests in `src/search/search_events_tests/no_match_tests.rs` covering scroll reset on no-match, horizontal scroll reset, scroll-restore on backspace into matching, and no-reset when query backspaces to empty.
- [x] Added 8 unit + render tests in `results_render_tests.rs` for the dim and badge behaviors across has-matches / no-matches / empty-query / confirmed states.
- [x] Updated existing `snapshot_search_bar_no_matches` snapshot to reflect the new badge in the title.
- [x] `cargo test --lib` (2999 tests pass).
- [x] `cargo clippy --all-targets --all-features` clean.
- [x] `cargo fmt --all --check` clean.
- [x] `cargo build --release` clean.
- [x] Manual TUI validation by user.