### PR TITLE
fix(input): show usage hint when clipboard is unavailable or has non-JSON

### DIFF
--- a/src/input/loader.rs
+++ b/src/input/loader.rs
@@ -181,27 +181,49 @@ fn load_stdin_sync() -> Result<String, JiqError> {
 
 /// Synchronous clipboard loading (runs in background thread)
 ///
-/// Reads text from the system clipboard and validates JSON. Returns an Io error
-/// when the clipboard is unavailable or empty so callers can surface a usage hint
-/// matching the no-input experience.
+/// Reads text from the system clipboard and validates JSON. The clipboard is a
+/// silent fallback when the user supplies neither a path nor piped stdin, so
+/// every failure mode (unavailable backend, empty clipboard, non-JSON content)
+/// is collapsed into the same usage hint the stdin path uses. Surfacing the
+/// raw `arboard` error - "X11 server connection timed out", etc. - is noisy
+/// and confusing on remote SSH sessions where the clipboard was never usable.
 fn load_clipboard_sync() -> Result<String, JiqError> {
     log::debug!("Loading from clipboard");
-    let mut clipboard = arboard::Clipboard::new()
-        .map_err(|e| JiqError::Io(format!("Clipboard unavailable: {}", e)))?;
-    let contents = clipboard
-        .get_text()
-        .map_err(|e| JiqError::Io(format!("Clipboard read failed: {}", e)))?;
+
+    let mut clipboard = match arboard::Clipboard::new() {
+        Ok(c) => c,
+        Err(e) => {
+            log::debug!("Clipboard unavailable: {}", e);
+            return Err(no_clipboard_input_error());
+        }
+    };
+
+    let contents = match clipboard.get_text() {
+        Ok(t) => t,
+        Err(e) => {
+            log::debug!("Clipboard read failed: {}", e);
+            return Err(no_clipboard_input_error());
+        }
+    };
     log::debug!("Clipboard read: {} bytes", contents.len());
 
     if contents.trim().is_empty() {
+        return Err(no_clipboard_input_error());
+    }
+
+    if validate_json_or_jsonl(&contents).is_err() {
+        log::debug!("Clipboard contents are not valid JSON or JSONL");
         return Err(JiqError::Io(
-            "No input provided. Usage: jiq <file> or echo '{}' | jiq".to_string(),
+            "No input provided and clipboard does not contain valid JSON. Usage: jiq <file> or echo '{}' | jiq"
+                .to_string(),
         ));
     }
 
-    validate_json_or_jsonl(&contents)?;
-
     Ok(contents)
+}
+
+fn no_clipboard_input_error() -> JiqError {
+    JiqError::Io("No input provided. Usage: jiq <file> or echo '{}' | jiq".to_string())
 }
 
 #[cfg(test)]

--- a/src/input/loader_tests.rs
+++ b/src/input/loader_tests.rs
@@ -189,6 +189,28 @@ fn test_spawn_load_clipboard_creates_loader() {
     assert!(matches!(loader.state(), LoadingState::Loading));
 }
 
+#[test]
+fn test_no_clipboard_input_error_is_friendly_usage_hint() {
+    let err = no_clipboard_input_error();
+    match err {
+        JiqError::Io(msg) => {
+            assert!(msg.contains("No input provided"));
+            assert!(msg.contains("Usage:"));
+            assert!(!msg.to_lowercase().contains("clipboard"));
+            assert!(!msg.to_lowercase().contains("x11"));
+        }
+        other => panic!("expected JiqError::Io, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_validate_json_or_jsonl_rejects_plain_text() {
+    // Mirrors the clipboard-with-non-JSON path: the caller surfaces a
+    // friendly usage hint when validation fails on clipboard contents.
+    let result = validate_json_or_jsonl("hello world");
+    assert!(result.is_err());
+}
+
 // ============================================================================
 // JSONL Validation Tests
 // ============================================================================


### PR DESCRIPTION
## Summary
- On remote SSH sessions without a real clipboard (no X11/Wayland, no OSC 52 read), launching `jiq` with no argument and no piped stdin previously surfaced a confusing raw `arboard` error such as `Failed to load file: I/O error, clipboard unavailable. ... X11 server connection timed out`.
- The clipboard fallback is silent (the user did not ask for it), so any failure - unavailable backend, empty clipboard, or non-JSON contents - now collapses into the same friendly usage hint the no-stdin path already shows.
- Two distinct messages so the cause is still discoverable without surfacing platform jargon:
  - Backend unavailable / empty / read failure → `No input provided. Usage: jiq <file> or echo '{}' | jiq`
  - Clipboard had text but it isn't JSON → `No input provided and clipboard does not contain valid JSON. Usage: jiq <file> or echo '{}' | jiq`
- Raw arboard error text is logged at debug level (visible with `--debug` / `JIQ_DEBUG=1`) for diagnosis.

## Test plan
- [x] `cargo test --lib` (3042 passed)
- [x] `cargo build --release`
- [x] `cargo clippy --all-targets --all-features` (zero warnings)
- [x] `cargo fmt --all --check`
- [x] Manual: launched `jiq` from an SSH session with no X11/Wayland - sees friendly usage hint, no `clipboard unavailable` jargon