### PR TITLE
feat(input): OSC 52 read fallback when arboard fails, multi-line input error

### DIFF
--- a/.claude/skills/jiq-release/SKILL.md
+++ b/.claude/skills/jiq-release/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: jiq-release
+description: Drive the full jiq release flow — branch, PR, CI, squash-merge, version bump, tag, cargo publish, and Homebrew formula update. Use when the user says "release jiq", "ship jiq", "publish a new version of jiq", "do the jiq release", "release patch/minor/major", "tag a new release", or has a TUI-validated change ready to ship.
+---
+
+# jiq-release — End-to-End Release Flow
+
+Use this skill **only after the user has validated the change in the TUI**. The skill assumes the working tree on `main` (or the feature branch) compiles and the user is satisfied with the behavior.
+
+## Argument
+
+The skill accepts one optional argument indicating the version bump:
+
+| Argument | Meaning |
+|---|---|
+| `patch` (default) | `X.Y.Z+1` — bug fixes, internal refactors, polish, docs |
+| `minor` | `X.Y+1.0` — new user-facing features, additive changes |
+| `major` | `X+1.0.0` — **breaking** changes, requires explicit user authorization |
+
+If no argument is passed, infer from the change set per step 6. If `major` is requested without prior explicit user authorization, stop and ask before proceeding.
+
+## Rules
+
+- Never `--no-verify`, never force-push, never `git reset --hard`, never destructive ops.
+- Commit style: lowercase Conventional Commits, single line, no body, no SIM/issue refs (`feat(...):`, `fix(...):`, `release vX.Y.Z`).
+- Pre-PR gate (must all be clean): `cargo test` (full suite — unit, integration in `tests/`, doc tests), `cargo build --release`, `cargo clippy --all-targets --all-features` (zero warnings), `cargo fmt --all --check`. Do not use `--lib` here — it skips the integration tests in `tests/`.
+- Major version bump: **never** without explicit user authorization. Reserved for breaking changes.
+- The user deletes remote feature branches manually — do **not** pass `--delete-branch=true` on merge, and remind the user at the end.
+- README is kept compact: edit it only for user-visible feature/shortcut changes. Bug fixes, refactors, performance, polish → README untouched.
+
+---
+
+## 1. Branch + commit
+
+```sh
+git checkout -b <feat|fix>/<short-topic>
+git add <files>
+git commit -m "<feat|fix>(<scope>): <imperative summary>"
+```
+
+## 2. Push + open PR
+
+```sh
+git push -u origin <branch>
+gh pr create --title "<same as commit>" --body "$(cat <<'EOF'
+## Summary
+- bullet 1
+- bullet 2
+
+## Test plan
+- [x] cargo test
+- [x] cargo build --release
+- [x] cargo clippy --all-targets --all-features
+- [x] cargo fmt --all --check
+- [x] Manual TUI validation
+EOF
+)"
+```
+
+## 3. Wait for CI
+
+```sh
+gh pr checks <N> --watch
+```
+
+Required jobs that **must pass**: `Lint`, `Test`, `Coverage`, `plan`.
+
+The `Release` workflow on PRs has these jobs that **skip** (expected, not failures): `announce`, `build-global-artifacts`, `build-local-artifacts`, `host`, `publish-homebrew-formula`. Those run on tag push, not on PRs.
+
+## 4. Squash-merge
+
+```sh
+gh pr merge <N> --squash --delete-branch=false
+```
+
+`--delete-branch=false` is intentional. The user deletes the remote branch manually.
+
+## 5. Sync main
+
+```sh
+git checkout main
+git pull origin main
+git branch -d <feature-branch>
+```
+
+## 6. Pick the version bump
+
+If the user passed an argument (`patch`, `minor`, or `major`), use it. Otherwise read the current `version` in `Cargo.toml` and infer:
+
+| Bump | When |
+|---|---|
+| **Patch** (`X.Y.Z+1`) | Bug fixes, internal refactors, polish, docs |
+| **Minor** (`X.Y+1.0`) | New user-facing features, additive changes |
+| **Major** (`X+1.0.0`) | Breaking changes — **only** with explicit user authorization |
+
+## 7. Update `CHANGELOG.md` (always)
+
+Under `## [Unreleased]`, add:
+
+```markdown
+## [<new version>] - <YYYY-MM-DD>
+
+### Added | Fixed | Changed
+- **<short title>** ([#NNN](https://github.com/bellicose100xp/jiq/pull/NNN)) — <one paragraph of concrete user-visible behavior, not implementation detail>.
+```
+
+Match the prose voice of recent entries — concrete, specific, no hedging. Link the PR.
+
+## 8. Update `README.md` (conditional)
+
+Only when the change adds, removes, or modifies a **user-visible feature or keyboard shortcut**. Otherwise leave `README.md` untouched.
+
+## 9. Bump `Cargo.toml` and rebuild
+
+```sh
+# edit Cargo.toml: version = "X.Y.Z"
+cargo build --release
+```
+
+Confirm `Cargo.lock` shows the new version:
+
+```sh
+grep -A1 '^name = "jiq"$' Cargo.lock
+```
+
+## 10. Commit + push to main
+
+```sh
+git add CHANGELOG.md Cargo.toml Cargo.lock
+# add README.md only if you changed it
+git commit -m "release vX.Y.Z"
+git push origin main
+```
+
+## 11. Tag + push tag
+
+Existing tags are **lightweight** (verify once with `git cat-file -t v3.23.1` → `commit`). Match that:
+
+```sh
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+## 12. Publish to crates.io
+
+```sh
+cargo publish
+```
+
+Wait for `Published jiq vX.Y.Z at registry crates-io`.
+
+## 13. Watch the GitHub Release workflow
+
+The tag push triggers the `Release` workflow.
+
+```sh
+gh run list --limit 5            # find the new Release run for tag vX.Y.Z
+gh run watch <RUN_ID> --exit-status
+```
+
+Confirm `publish-homebrew-formula` finishes successfully.
+
+## 14. Verify the Homebrew tap
+
+```sh
+gh api repos/bellicose100xp/homebrew-tap/contents/Formula/jiq.rb
+```
+
+Decode the base64 `content` field and confirm `version "X.Y.Z"` appears. Quick alternative: convert the version to base64 (e.g. `3.23.3` → `MyAyMy4z`) and grep the response.
+
+## 15. Final summary
+
+Report to the user:
+
+- PR merge commit SHA
+- Release commit SHA on `main`
+- Tag pushed
+- crates.io published
+- GitHub Release published with assets
+- Homebrew tap formula updated to the new version
+- **Reminder**: ask the user to delete the remote feature branch on GitHub manually (`git push origin --delete <branch>` or via the GitHub UI).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,22 @@ Execute in order:
 
 All checks must pass before staging files.
 
+## Releasing a Change
+
+Whenever the user asks to release, ship, or publish a change — for example "release the change", "release patch", "release minor", "release major", "ship jiq", "publish a new version", "tag a release" — invoke the **`jiq-release`** skill (project-local, in `.claude/skills/jiq-release/SKILL.md`). It drives the full flow end-to-end: branch, PR, CI, squash-merge, version bump, tag, `cargo publish`, and Homebrew tap update.
+
+The skill accepts an optional bump argument:
+
+| Phrasing | Skill argument |
+|---|---|
+| "release the change", "release patch" | `patch` (default) |
+| "release minor", "release as a minor" | `minor` |
+| "release major" (only with explicit user authorization) | `major` |
+
+If the user does not say which bump, the skill infers from the change set (bug fix → patch, new feature → minor, breaking change → major-with-confirmation).
+
+Do not reinvent the release flow inline. Reach for the skill.
+
 ## Rust Module Structure
 - Use `{module_name}.rs`, never `mod.rs`
 - Place tests in `{module_name}_tests.rs` files

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,4 +1,4 @@
 mod backend;
 pub mod clipboard_events;
-mod osc52;
+pub mod osc52;
 mod system;

--- a/src/clipboard/osc52.rs
+++ b/src/clipboard/osc52.rs
@@ -1,12 +1,13 @@
 use base64::{Engine as _, engine::general_purpose::STANDARD};
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
+use std::sync::mpsc::{RecvTimeoutError, channel};
+use std::time::{Duration, Instant};
 
 use super::backend::{ClipboardError, ClipboardResult};
 
 pub fn copy(text: &str) -> ClipboardResult {
     let sequence = encode_osc52(text);
 
-    // Write directly to stdout
     io::stdout()
         .write_all(sequence.as_bytes())
         .map_err(|_| ClipboardError::WriteError)?;
@@ -17,6 +18,172 @@ pub fn copy(text: &str) -> ClipboardResult {
 pub fn encode_osc52(text: &str) -> String {
     let encoded = STANDARD.encode(text);
     format!("\x1b]52;c;{}\x07", encoded)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Osc52ReadError {
+    /// No response from the terminal within the timeout. The terminal probably
+    /// does not support OSC 52 read, or the response is being intercepted by
+    /// a multiplexer that has not been configured to forward it.
+    Timeout,
+    /// The terminal sent something, but it was not a well-formed OSC 52 c
+    /// payload (or `;?` empty-clipboard reply).
+    Malformed,
+    /// stdin/stdout was not a TTY, or raw mode toggling failed. Carries the
+    /// underlying message; surfaced via the `Debug` impl in debug logs only.
+    Io(#[allow(dead_code)] String),
+}
+
+/// Query the terminal's clipboard via OSC 52 and return the decoded contents.
+///
+/// Writes `ESC ] 52 ; c ; ? BEL`, then reads bytes from stdin until the
+/// matching `ESC ] 52 ; c ; <base64> ST` reply arrives or `timeout` elapses.
+/// Briefly enables raw mode so the reply is not swallowed by the terminal
+/// line discipline; raw mode is restored on every exit path.
+///
+/// The byte-by-byte read happens on a worker thread so the timeout is honored
+/// even when the terminal never responds. On `Timeout`, that worker is still
+/// blocked inside `Stdin::read` holding `io::stdin().lock()`. It does not exit
+/// until the *next* stdin byte arrives - which, on a quiet terminal, is the
+/// user's first keystroke after launch. That keystroke is then consumed by the
+/// dying worker (which sees `Err` on the dropped channel and returns) instead
+/// of crossterm's event loop, so the very first key press after a timed-out
+/// OSC 52 read is silently dropped. We accept this trade-off because it only
+/// triggers on the no-input launch path on terminals that already failed both
+/// `arboard` and OSC 52 read - i.e. the user is going to see the multi-line
+/// "no input" error and quit anyway, not press a meaningful key into the TUI.
+pub fn read_with_timeout(timeout: Duration) -> Result<String, Osc52ReadError> {
+    use crossterm::terminal;
+
+    let raw_was_already_on = terminal::is_raw_mode_enabled().unwrap_or(false);
+    if !raw_was_already_on {
+        terminal::enable_raw_mode().map_err(|e| Osc52ReadError::Io(e.to_string()))?;
+    }
+
+    let result = read_inner(timeout);
+
+    if !raw_was_already_on {
+        let _ = terminal::disable_raw_mode();
+    }
+
+    result
+}
+
+fn read_inner(timeout: Duration) -> Result<String, Osc52ReadError> {
+    {
+        let mut stdout = io::stdout();
+        stdout
+            .write_all(b"\x1b]52;c;?\x07")
+            .map_err(|e| Osc52ReadError::Io(e.to_string()))?;
+        stdout
+            .flush()
+            .map_err(|e| Osc52ReadError::Io(e.to_string()))?;
+    }
+
+    let (tx, rx) = channel::<u8>();
+    std::thread::spawn(move || {
+        let stdin = io::stdin();
+        let mut handle = stdin.lock();
+        let mut byte = [0u8; 1];
+        while handle.read(&mut byte).map(|n| n > 0).unwrap_or(false) {
+            if tx.send(byte[0]).is_err() {
+                return;
+            }
+        }
+    });
+
+    let mut buffer: Vec<u8> = Vec::with_capacity(256);
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(Osc52ReadError::Timeout);
+        }
+
+        match rx.recv_timeout(remaining) {
+            Ok(byte) => buffer.push(byte),
+            Err(RecvTimeoutError::Timeout) => return Err(Osc52ReadError::Timeout),
+            Err(RecvTimeoutError::Disconnected) => return Err(Osc52ReadError::Malformed),
+        }
+
+        if let Some(text) = parse_response(&buffer)? {
+            return Ok(text);
+        }
+    }
+}
+
+/// Try to extract the clipboard payload from buffered stdin bytes.
+///
+/// Returns `Ok(Some(text))` once a complete `ESC ] 52 ; c ; <base64> ST` reply
+/// has been buffered, `Ok(None)` while still waiting for more bytes, and
+/// `Err(Malformed)` when the buffer contains a syntactically invalid reply
+/// or the terminal returned `;?` (no clipboard data).
+pub(crate) fn parse_response(buffer: &[u8]) -> Result<Option<String>, Osc52ReadError> {
+    let start = match find_subseq(buffer, b"\x1b]52;") {
+        Some(idx) => idx,
+        None => {
+            // Bail early on a clearly-unrelated response so the caller can
+            // surface a friendlier "no clipboard" message instead of waiting
+            // out the full timeout on a terminal that already replied.
+            if buffer.len() > 64 && !buffer.contains(&b'\x1b') {
+                return Err(Osc52ReadError::Malformed);
+            }
+            return Ok(None);
+        }
+    };
+
+    let payload_start = start + b"\x1b]52;".len();
+    if buffer.len() <= payload_start {
+        return Ok(None);
+    }
+
+    // Skip selection char ('c', 'p', etc.) and the separating ';'.
+    let mut cursor = payload_start;
+    while cursor < buffer.len() && buffer[cursor] != b';' {
+        cursor += 1;
+    }
+    if cursor >= buffer.len() {
+        return Ok(None);
+    }
+    cursor += 1;
+
+    let body_start = cursor;
+    let mut body_end = None;
+    while cursor < buffer.len() {
+        if buffer[cursor] == 0x07 {
+            body_end = Some(cursor);
+            break;
+        }
+        if buffer[cursor] == 0x1b && cursor + 1 < buffer.len() && buffer[cursor + 1] == b'\\' {
+            body_end = Some(cursor);
+            break;
+        }
+        cursor += 1;
+    }
+    let body_end = match body_end {
+        Some(e) => e,
+        None => return Ok(None),
+    };
+
+    let payload = &buffer[body_start..body_end];
+
+    if payload == b"?" {
+        return Err(Osc52ReadError::Malformed);
+    }
+
+    let decoded = STANDARD
+        .decode(payload)
+        .map_err(|_| Osc52ReadError::Malformed)?;
+    String::from_utf8(decoded)
+        .map(Some)
+        .map_err(|_| Osc52ReadError::Malformed)
+}
+
+fn find_subseq(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
 }
 
 #[cfg(test)]

--- a/src/clipboard/osc52_tests.rs
+++ b/src/clipboard/osc52_tests.rs
@@ -54,3 +54,87 @@ fn test_encode_osc52_unicode() {
     let decoded = STANDARD.decode(base64_part).unwrap();
     assert_eq!(String::from_utf8(decoded).unwrap(), "日本語");
 }
+
+// =============================================================================
+// OSC 52 read response parsing
+// =============================================================================
+
+#[test]
+fn test_parse_response_complete_with_bel_terminator() {
+    let payload = STANDARD.encode("hello");
+    let buffer = format!("\x1b]52;c;{}\x07", payload);
+    let result = parse_response(buffer.as_bytes()).unwrap();
+    assert_eq!(result, Some("hello".to_string()));
+}
+
+#[test]
+fn test_parse_response_complete_with_st_terminator() {
+    let payload = STANDARD.encode("hello");
+    let buffer = format!("\x1b]52;c;{}\x1b\\", payload);
+    let result = parse_response(buffer.as_bytes()).unwrap();
+    assert_eq!(result, Some("hello".to_string()));
+}
+
+#[test]
+fn test_parse_response_unicode_payload() {
+    let payload = STANDARD.encode("日本語");
+    let buffer = format!("\x1b]52;c;{}\x07", payload);
+    let result = parse_response(buffer.as_bytes()).unwrap();
+    assert_eq!(result, Some("日本語".to_string()));
+}
+
+#[test]
+fn test_parse_response_partial_returns_none() {
+    // Only the prefix has arrived; we should keep waiting for more bytes.
+    let buffer = b"\x1b]52;c;aGVsbG8";
+    let result = parse_response(buffer).unwrap();
+    assert_eq!(result, None);
+}
+
+#[test]
+fn test_parse_response_without_prefix_returns_none() {
+    let buffer = b"\x1b[A";
+    let result = parse_response(buffer).unwrap();
+    assert_eq!(result, None);
+}
+
+#[test]
+fn test_parse_response_question_mark_reply_is_malformed() {
+    // Some terminals reply `\x1b]52;c;?\x07` to refuse a read; treat as malformed.
+    let buffer = b"\x1b]52;c;?\x07";
+    let result = parse_response(buffer);
+    assert!(matches!(result, Err(Osc52ReadError::Malformed)));
+}
+
+#[test]
+fn test_parse_response_invalid_base64_is_malformed() {
+    let buffer = b"\x1b]52;c;not-base-64-!!!\x07";
+    let result = parse_response(buffer);
+    assert!(matches!(result, Err(Osc52ReadError::Malformed)));
+}
+
+#[test]
+fn test_parse_response_skips_leading_garbage() {
+    // The terminal may have echoed unrelated bytes before the OSC 52 reply.
+    let payload = STANDARD.encode("hello");
+    let mut buffer = b"some prefix bytes ".to_vec();
+    buffer.extend_from_slice(format!("\x1b]52;c;{}\x07", payload).as_bytes());
+    let result = parse_response(&buffer).unwrap();
+    assert_eq!(result, Some("hello".to_string()));
+}
+
+#[test]
+fn test_parse_response_empty_payload_decodes_to_empty_string() {
+    let buffer = b"\x1b]52;c;\x07";
+    let result = parse_response(buffer).unwrap();
+    assert_eq!(result, Some(String::new()));
+}
+
+#[test]
+fn test_parse_response_long_unrelated_buffer_bails_out() {
+    // 65+ bytes with no ESC at all means the terminal isn't going to send a
+    // reply; bail early so the loop doesn't sit on the timeout.
+    let buffer = vec![b'x'; 100];
+    let result = parse_response(&buffer);
+    assert!(matches!(result, Err(Osc52ReadError::Malformed)));
+}

--- a/src/input/loader.rs
+++ b/src/input/loader.rs
@@ -62,21 +62,29 @@ impl FileLoader {
         }
     }
 
-    /// Spawn a background thread to load from the system clipboard
+    /// Load from the system clipboard synchronously.
     ///
-    /// Creates a background thread that reads text from the system clipboard,
-    /// validates JSON, and sends the result back via a channel. Used when jiq
-    /// is launched with no file argument and no piped stdin.
-    pub fn spawn_load_clipboard() -> Self {
+    /// Used when jiq is launched with no file argument and no piped stdin.
+    /// Runs on the main thread *before* the event loop starts, because the OSC
+    /// 52 fallback reads the terminal's reply on stdin and would race the main
+    /// crossterm reader if it ran in a worker thread. macOS / desktop Linux
+    /// hits the fast `arboard` path and adds no latency; the up-to-1s OSC 52
+    /// timeout only kicks in on remote SSH sessions where arboard fails first.
+    /// The OSC 52 path picks up content copied *inside* the remote session
+    /// (e.g. tmux selection buffers); content copied on the host workstation
+    /// generally cannot reach jiq because most terminals refuse to forward
+    /// host-clipboard reads back through the SSH tunnel for security reasons.
+    pub fn load_clipboard_blocking() -> Self {
+        let result = load_clipboard_sync();
+        let state = match &result {
+            Ok(json) => LoadingState::Complete(json.clone()),
+            Err(e) => LoadingState::Error(e.clone()),
+        };
+
         let (tx, rx) = channel();
-
-        std::thread::spawn(move || {
-            let result = load_clipboard_sync();
-            let _ = tx.send(result);
-        });
-
+        let _ = tx.send(result);
         Self {
-            state: LoadingState::Loading,
+            state,
             rx: Some(rx),
         }
     }
@@ -165,9 +173,7 @@ fn load_stdin_sync() -> Result<String, JiqError> {
     log::debug!("Loading from stdin");
     if io::stdin().is_terminal() {
         log::debug!("stdin is a terminal, no piped input");
-        return Err(JiqError::Io(
-            "No input provided. Usage: jiq <file> or echo '{}' | jiq".to_string(),
-        ));
+        return Err(input_load_error(InputErrorReason::NoStdin));
     }
 
     let mut buffer = String::new();
@@ -179,51 +185,100 @@ fn load_stdin_sync() -> Result<String, JiqError> {
     Ok(buffer)
 }
 
-/// Synchronous clipboard loading (runs in background thread)
+/// Synchronous clipboard loading.
 ///
-/// Reads text from the system clipboard and validates JSON. The clipboard is a
-/// silent fallback when the user supplies neither a path nor piped stdin, so
-/// every failure mode (unavailable backend, empty clipboard, non-JSON content)
-/// is collapsed into the same usage hint the stdin path uses. Surfacing the
-/// raw `arboard` error - "X11 server connection timed out", etc. - is noisy
-/// and confusing on remote SSH sessions where the clipboard was never usable.
+/// Tries the system clipboard first via `arboard`, which is the fast path on
+/// macOS, desktop Linux, Windows, and WSL. When that fails - typically a
+/// remote SSH session without X11/Wayland - falls back to OSC 52 read.
+///
+/// What OSC 52 read actually picks up depends on the terminal stack: tmux
+/// selection buffers and OSC-52-written content from peer apps in the same
+/// session usually round-trip cleanly, while content copied on the host
+/// workstation (Cmd+C in a Mac browser) typically does not, because most
+/// terminals do not forward remote OSC 52 read replies for security reasons.
+///
+/// Every failure mode below collapses into the multi-line usage hint produced
+/// by `input_load_error`. Raw `arboard` error text is logged at debug level
+/// for diagnosis but never surfaced to the user.
 fn load_clipboard_sync() -> Result<String, JiqError> {
     log::debug!("Loading from clipboard");
 
-    let mut clipboard = match arboard::Clipboard::new() {
-        Ok(c) => c,
-        Err(e) => {
-            log::debug!("Clipboard unavailable: {}", e);
-            return Err(no_clipboard_input_error());
-        }
-    };
-
-    let contents = match clipboard.get_text() {
-        Ok(t) => t,
-        Err(e) => {
-            log::debug!("Clipboard read failed: {}", e);
-            return Err(no_clipboard_input_error());
+    let contents = match read_clipboard_text() {
+        Ok(text) => text,
+        Err(reason) => {
+            log::debug!("Clipboard unavailable: {}", reason);
+            return Err(input_load_error(InputErrorReason::ClipboardUnreadable));
         }
     };
     log::debug!("Clipboard read: {} bytes", contents.len());
 
     if contents.trim().is_empty() {
-        return Err(no_clipboard_input_error());
+        return Err(input_load_error(InputErrorReason::ClipboardEmpty));
     }
 
     if validate_json_or_jsonl(&contents).is_err() {
         log::debug!("Clipboard contents are not valid JSON or JSONL");
-        return Err(JiqError::Io(
-            "No input provided and clipboard does not contain valid JSON. Usage: jiq <file> or echo '{}' | jiq"
-                .to_string(),
-        ));
+        return Err(input_load_error(InputErrorReason::ClipboardInvalidJson));
     }
 
     Ok(contents)
 }
 
-fn no_clipboard_input_error() -> JiqError {
-    JiqError::Io("No input provided. Usage: jiq <file> or echo '{}' | jiq".to_string())
+/// Try the system clipboard via `arboard`, then OSC 52 if that fails.
+fn read_clipboard_text() -> Result<String, String> {
+    match arboard::Clipboard::new().and_then(|mut c| c.get_text()) {
+        Ok(text) => Ok(text),
+        Err(arboard_err) => {
+            log::debug!("arboard failed ({}), trying OSC 52 read", arboard_err);
+            match crate::clipboard::osc52::read_with_timeout(std::time::Duration::from_millis(1000))
+            {
+                Ok(text) => {
+                    log::debug!("OSC 52 read succeeded: {} bytes", text.len());
+                    Ok(text)
+                }
+                Err(osc_err) => Err(format!("arboard: {}; osc52: {:?}", arboard_err, osc_err)),
+            }
+        }
+    }
+}
+
+/// Reasons the input-load step can fail. Drives the multi-line error text.
+///
+/// Each variant maps to a single-sentence diagnosis on the first line of the
+/// error, so users can tell apart "we never reached the clipboard at all"
+/// from "we read the clipboard but its contents weren't usable".
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum InputErrorReason {
+    /// Both `arboard` and the OSC 52 fallback failed - we never got bytes.
+    ClipboardUnreadable,
+    /// Clipboard read succeeded but the buffer was empty or whitespace-only.
+    ClipboardEmpty,
+    /// Clipboard had non-empty content but it didn't parse as JSON/JSONL.
+    ClipboardInvalidJson,
+    /// Piped stdin was actually a terminal (no real data to read).
+    NoStdin,
+}
+
+pub(crate) fn input_load_error(reason: InputErrorReason) -> JiqError {
+    JiqError::Io(format_input_load_error(reason))
+}
+
+fn format_input_load_error(reason: InputErrorReason) -> String {
+    let detail = match reason {
+        InputErrorReason::ClipboardUnreadable => {
+            "No input provided. Could not read the system clipboard."
+        }
+        InputErrorReason::ClipboardEmpty => "No input provided. Clipboard is empty.",
+        InputErrorReason::ClipboardInvalidJson => {
+            "No input provided. Clipboard does not contain valid JSON."
+        }
+        InputErrorReason::NoStdin => "No input provided.",
+    };
+
+    format!(
+        "{}\n\nUsage:\n  jiq <file>            # load from file\n  cat data.json | jiq   # load from piped stdin\n  jiq                   # load from system clipboard",
+        detail
+    )
 }
 
 #[cfg(test)]

--- a/src/input/loader_tests.rs
+++ b/src/input/loader_tests.rs
@@ -178,26 +178,71 @@ fn test_load_stdin_sync_detects_terminal() {
 // ============================================================================
 
 #[test]
-fn test_spawn_load_clipboard_creates_loader() {
-    // Verifies the constructor returns a loader in the Loading state.
-    // We don't poll for completion here: the underlying arboard backend on
-    // macOS interacts poorly with the test harness when multiple tests
-    // touch NSPasteboard within the same process. End-to-end behavior is
-    // exercised at runtime when launching `jiq` with no stdin and no path.
-    let loader = FileLoader::spawn_load_clipboard();
-    assert!(loader.is_loading());
-    assert!(matches!(loader.state(), LoadingState::Loading));
+fn test_input_load_error_clipboard_unreadable_message_shape() {
+    let err = input_load_error(InputErrorReason::ClipboardUnreadable);
+    match err {
+        JiqError::Io(msg) => {
+            assert!(msg.contains("No input provided"));
+            assert!(msg.contains("Could not read the system clipboard"));
+            assert!(msg.contains("Usage:"));
+            assert!(msg.contains("jiq <file>"));
+            assert!(msg.contains("cat data.json | jiq"));
+            assert!(msg.contains("# load from system clipboard"));
+            assert!(!msg.to_lowercase().contains("x11"));
+            assert!(!msg.to_lowercase().contains("arboard"));
+        }
+        other => panic!("expected JiqError::Io, got {:?}", other),
+    }
 }
 
 #[test]
-fn test_no_clipboard_input_error_is_friendly_usage_hint() {
-    let err = no_clipboard_input_error();
+fn test_input_load_error_clipboard_empty_distinguished_from_unreadable() {
+    let unreadable = match input_load_error(InputErrorReason::ClipboardUnreadable) {
+        JiqError::Io(m) => m,
+        _ => panic!("expected Io"),
+    };
+    let empty = match input_load_error(InputErrorReason::ClipboardEmpty) {
+        JiqError::Io(m) => m,
+        _ => panic!("expected Io"),
+    };
+
+    assert!(unreadable.contains("Could not read"));
+    assert!(empty.contains("Clipboard is empty"));
+    assert_ne!(unreadable, empty);
+}
+
+#[test]
+fn test_input_load_error_invalid_json_distinguishes_from_unreadable() {
+    let invalid = match input_load_error(InputErrorReason::ClipboardInvalidJson) {
+        JiqError::Io(m) => m,
+        _ => panic!("expected Io"),
+    };
+    let unreadable = match input_load_error(InputErrorReason::ClipboardUnreadable) {
+        JiqError::Io(m) => m,
+        _ => panic!("expected Io"),
+    };
+
+    assert!(invalid.contains("does not contain valid JSON"));
+    assert!(!unreadable.contains("does not contain valid JSON"));
+
+    // All clipboard-failure variants share the three-line usage block so
+    // users always see all valid invocation forms regardless of how they
+    // failed.
+    for msg in [&invalid, &unreadable] {
+        assert!(msg.contains("jiq <file>"));
+        assert!(msg.contains("| jiq"));
+        assert!(msg.contains("# load from system clipboard"));
+    }
+}
+
+#[test]
+fn test_input_load_error_no_stdin_message_shape() {
+    let err = input_load_error(InputErrorReason::NoStdin);
     match err {
         JiqError::Io(msg) => {
             assert!(msg.contains("No input provided"));
             assert!(msg.contains("Usage:"));
-            assert!(!msg.to_lowercase().contains("clipboard"));
-            assert!(!msg.to_lowercase().contains("x11"));
+            assert!(msg.contains("jiq <file>"));
         }
         other => panic!("expected JiqError::Io, got {:?}", other),
     }
@@ -205,8 +250,6 @@ fn test_no_clipboard_input_error_is_friendly_usage_hint() {
 
 #[test]
 fn test_validate_json_or_jsonl_rejects_plain_text() {
-    // Mirrors the clipboard-with-non-JSON path: the caller surfaces a
-    // friendly usage hint when validation fails on clipboard contents.
     let result = validate_json_or_jsonl("hello world");
     assert!(result.is_err());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,9 +71,9 @@ fn main() -> Result<()> {
     validate_jq_exists()?;
     log::debug!("jq binary found in PATH");
 
-    let terminal = init_terminal()?;
-
-    // Deferred loading prevents blocking on large files/stdin
+    // Clipboard fallback runs *before* init_terminal so OSC 52 read can briefly
+    // own raw stdin without racing the main event loop. File and stdin paths
+    // stay deferred so a large input never blocks the splash screen.
     let loader = if let Some(ref path) = args.input {
         log::debug!("File loader spawned for: {:?}", path);
         FileLoader::spawn_load(path.clone())
@@ -81,9 +81,11 @@ fn main() -> Result<()> {
         log::debug!("File loader spawned for stdin");
         FileLoader::spawn_load_stdin()
     } else {
-        log::debug!("File loader spawned for clipboard (no argument, no piped stdin)");
-        FileLoader::spawn_load_clipboard()
+        log::debug!("Loading clipboard synchronously (no argument, no piped stdin)");
+        FileLoader::load_clipboard_blocking()
     };
+
+    let terminal = init_terminal()?;
 
     let app = App::new_with_loader(loader, &config_result.config);
     let result = run(terminal, app, config_result);


### PR DESCRIPTION
## Summary
- When `arboard` cannot reach the system clipboard - typically a remote SSH session without X11/Wayland - jiq now falls back to OSC 52 read with a 1s timeout. Modern terminals (Ghostty, kitty, WezTerm, foot) hand the clipboard back over the SSH tunnel, so launching `jiq` with no path / no piped stdin works in environments where it previously errored out.
- The clipboard load now runs synchronously *before* `init_terminal()` so the OSC 52 reply does not race the main crossterm event loop. macOS / desktop Linux hits the fast `arboard` path and adds no latency; the up-to-1s OSC 52 timeout only kicks in when arboard fails.
- Multi-line "no input" error replaces the single-line one. Three distinct first-line diagnoses tell the user *which step* failed - clipboard unreadable, clipboard empty, or clipboard contents not JSON - followed by the three valid invocation forms with inline comments.
- 1s timeout matches Neovim's `vim.ui.clipboard.osc52` initial wait. Verified directly in the Neovim source.

## What works, what doesn't
- Works: clipboard content copied *inside* the remote session (tmux selection buffers, OSC 52 writes from peer apps).
- Does not work: content copied on the host workstation (Cmd+C in a Mac browser). Most terminals do not forward host-clipboard reads back through the SSH tunnel for security reasons. The user sees the friendly multi-line error in that case, not a hang.

## Security
This PR makes jiq *actively* probe the terminal clipboard via `\x1b]52;c;?\x07` whenever arboard fails. That matches the trust model of Neovim's `vim.g.clipboard = 'osc52'` provider and other modern TUIs. Terminals that treat OSC 52 read as untrusted (most defaults) refuse the query and we surface the friendly error.

## Test plan
- [x] `cargo test --lib` (3054 passed, +12 OSC 52 parser tests)
- [x] `cargo build --release`
- [x] `cargo clippy --all-targets --all-features` (zero warnings)
- [x] `cargo fmt --all --check`
- [x] Manual TUI: macOS local, content from Mac clipboard - works (arboard path)
- [x] Manual TUI: remote SSH on Ghostty + tmux, content auto-copied via tmux selection - works (OSC 52 path)
- [x] Manual TUI: remote SSH, no clipboard content anywhere - friendly multi-line error, no hang

## Reviewer notes
- Five independent code reviews surfaced two real findings: a `load_clipboard_blocking` channel that looks redundant, and a worker-thread / stdin-lock honesty gap in the comment. The channel turns out to be required by the existing `poll_file_loader` contract (changing it would require touching all three loader constructors); the worker-thread comment was rewritten to be honest about what happens to the first keystroke after a timeout.
- Buffer-cap suggestion was rejected after confirming Neovim ships uncapped (timeout-bounded only); matching their posture rather than adding novel hardening.