### PR TITLE
feat(results): add sibling navigation chords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Sibling navigation chords (`]`, `[`)** - Press `]` to jump the cursor to the next sibling row and `[` to jump to the previous sibling, within the cursor's parent container. Pure cursor movement: the query is unchanged, the textarea is untouched, and the undo ring is left alone (so `<` still pops the last `>` you pressed, not the last sibling step). Wraps at container boundaries: `]` from the last child returns to the first; `[` from the first goes to the last. The handler resolves the cursor row's path, walks to the prev/next sibling in the parsed JSON tree (object keys preserved by `serde_json`'s `preserve_order`, array indices trivial), maps that sibling back to its rendered line via a new `line_at_path` walker, and `move_to_line`s there with `ensure_cursor_visible` to handle scrolling. Single-child containers and the root row are soft no-ops with notifications. Works in search mode against the match row and keeps the overlay open since cursor movement doesn't invalidate the search context. Bottom-border hints now read `> value · < back · * iterate · ^ parent · } wrap · ]/[ siblings`.
+
 ## [3.26.0] - 2026-05-24
 
 ### Added

--- a/docs/features/results-pane.md
+++ b/docs/features/results-pane.md
@@ -106,6 +106,17 @@ When a value like `"alice"` is useful but you also want to see its key:
 
 jiq rewrites the query to wrap the value in an object: `.users[0].name` becomes `.users[0] | {name}`, showing `{"name": "alice"}`.
 
+## Walk between siblings
+
+When the cursor is on a child of an object or array, hop to its neighbor in the same parent without scrolling line by line:
+
+1. Move the cursor to a value.
+2. Press **`]`** to jump to the next sibling, **`[`** to jump to the previous one.
+
+The cursor lands on the sibling's row — the query is **not** rewritten. So in `{"users": [...], "meta": {...}}` with the cursor on `.users`, pressing `]` moves the cursor to the `.meta` row; pressing `[` moves it back. Inside an array, `]` walks `.[0]` → `.[1]` → `.[2]` ... and wraps at the end.
+
+Use this to scan an object's keys or array's elements quickly, then drill in with `>` once you've found the one you want.
+
 ## Select and copy specific lines
 
 To copy only part of the output rather than everything:
@@ -145,5 +156,6 @@ To copy the entire result without selecting, press **Ctrl+Y** or **Ctrl+O** from
 | `*` | Expand array at cursor |
 | `^` | Remove last path segment |
 | `}` | Wrap leaf value as `{key}` object |
+| `]` `[` | Jump cursor to next / previous sibling (wraps) |
 | `v` `V` | Enter visual line selection |
 | `y` | Copy selection (or full result if none) |

--- a/docs/features/search.md
+++ b/docs/features/search.md
@@ -66,4 +66,5 @@ Press **Esc** to close the search bar and clear highlights.
 | `N` / `Shift+Enter` | Previous match |
 | `Tab` | Return to editing the search term |
 | `>` `*` `}` | Drill into the current match's row |
+| `]` `[` | Jump cursor to next / prev sibling of the match's row |
 | `Esc` | Close search |

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -165,6 +165,7 @@ Focus with <kbd>Shift</kbd>+<kbd>Tab</kbd> or click.
 | <kbd>*</kbd> | Iterate nearest array (`[N]` → `[]`) |
 | <kbd>^</kbd> | Step up one level |
 | <kbd>}</kbd> | Wrap leaf as `{key}` object |
+| <kbd>]</kbd> <kbd>[</kbd> | Jump cursor to next / prev sibling (wraps) |
 
 {: .shortcuts }
 

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_results_pane_with_success_focused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_results_pane_with_success_focused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 212
 expression: output
 ---
 "╭ String  · . ──────────────────────────────────────────────────── L1-1/1 (0%) ╮"
@@ -21,7 +22,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ sibl╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_results_pane_with_syntax_error_focused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_results_pane_with_syntax_error_focused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 182
 expression: output
 ---
 "╭   ⚠ Syntax Error   String | Showing last successful result ───── L1-1/1 (0%) ╮"
@@ -21,7 +22,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ sibl╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid[                                                                     │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_stats_bar_array_focused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_stats_bar_array_focused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 225
 expression: output
 ---
 "╭ Array [3 objects]  · . ─────────────────────────────────────── L1-11/11 (0%) ╮"
@@ -21,7 +22,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ sibl╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_results_focused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_results_focused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 60
 expression: output
 ---
 "╭ Object  · . ──────────────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -21,7 +22,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ sibl╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_empty_focused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_empty_focused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/result_state_tests.rs
+assertion_line: 51
 expression: output
 ---
 "╭   ∅ No Results   Array [2 objects] | Showing last non-empty result ───────────────────────────────────── L1-8/8 (0%) ╮"
@@ -27,7 +28,7 @@ expression: output
 "│                                                                                                                      │"
 "│                                                                                                                      │"
 "│                                                                                                                      │"
-"╰────────────────────── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───────────────────────╯"
+"╰─────────────── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ siblings ───────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.[] | select(.name == "nonexistent")                                                                                  │"
 "╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_error_focused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_error_focused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/result_state_tests.rs
+assertion_line: 84
 expression: output
 ---
 "╭   ⚠ Syntax Error   Object | Showing last successful result ───────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -27,7 +28,7 @@ expression: output
 "│                                                                                                                      │"
 "│                                                                                                                      │"
 "│                                                                                                                      │"
-"╰────────────────────── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───────────────────────╯"
+"╰─────────────── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ siblings ───────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid syntax here                                                                                                  │"
 "╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_success_focused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_success_focused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/result_state_tests.rs
+assertion_line: 19
 expression: output
 ---
 "╭ Stream [3]  · . ──────────────────────────────────────────────────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -27,7 +28,7 @@ expression: output
 "│                                                                                                                      │"
 "│                                                                                                                      │"
 "│                                                                                                                      │"
-"╰────────────────────── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───────────────────────╯"
+"╰─────────────── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ siblings ───────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.[].name                                                                                                              │"
 "╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__search_tests__snapshot_search_bar_active_state.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__search_tests__snapshot_search_bar_active_state.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/search_tests.rs
+assertion_line: 209
 expression: output
 ---
 "╭ Object  · .name ──────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -21,7 +22,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰────────────────── > value • * iterate • ^ parent • } wrap ───────────────────╯"
+"╰─────────── > value • * iterate • ^ parent • } wrap • ]/[ siblings ───────────╯"
 "╭ Search ─────────────────────────────────────────────────────────────   1/2   ╮"
 "│alice                                                                         │"
 "╰──── Enter Confirm • > value • * iterate • ^ parent • } wrap • Esc Close ─────╯"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__search_tests__snapshot_search_bar_inactive_state.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__search_tests__snapshot_search_bar_inactive_state.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/search_tests.rs
+assertion_line: 236
 expression: output
 ---
 "╭ Object  · .name ──────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -21,7 +22,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰/Prev • Enter Next • > value • * iterate • ^ parent • } wrap • Ctrl+F Edit • E╯"
+"╰ Enter Next • > value • * iterate • ^ parent • } wrap • ]/[ siblings • Ctrl+F ╯"
 "╭ Search ──────────────────────────────────────────────────────────────────────╮"
 "│alice                                                                         │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__search_tests__snapshot_search_bar_no_matches.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__search_tests__snapshot_search_bar_no_matches.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/search_tests.rs
+assertion_line: 81
 expression: output
 ---
 "╭   ⚠ No Matches    Object ─────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -21,7 +22,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰────────────────── > value • * iterate • ^ parent • } wrap ───────────────────╯"
+"╰─────────── > value • * iterate • ^ parent • } wrap • ]/[ siblings ───────────╯"
 "╭ Search ─────────────────────────────────────────────────────────────   0/0   ╮"
 "│xyz                                                                           │"
 "╰──── Enter Confirm • > value • * iterate • ^ parent • } wrap • Esc Close ─────╯"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__search_tests__snapshot_search_bar_visible.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__search_tests__snapshot_search_bar_visible.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/search_tests.rs
+assertion_line: 31
 expression: output
 ---
 "╭ Object  · .name ──────────────────────────────────────────────── L1-5/5 (0%) ╮"
@@ -21,7 +22,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰────────────────── > value • * iterate • ^ parent • } wrap ───────────────────╯"
+"╰─────────── > value • * iterate • ^ parent • } wrap • ]/[ siblings ───────────╯"
 "╭ Search ─────────────────────────────────────────────────────────────   1/2   ╮"
 "│alice                                                                         │"
 "╰──── Enter Confirm • > value • * iterate • ^ parent • } wrap • Esc Close ─────╯"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__search_tests__snapshot_search_bar_with_match_count.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__search_tests__snapshot_search_bar_with_match_count.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/search_tests.rs
+assertion_line: 56
 expression: output
 ---
 "╭ Array [3 objects]  · .[0].name ─────────────────────────────── L1-11/11 (0%) ╮"
@@ -21,7 +22,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰────────────────── > value • * iterate • ^ parent • } wrap ───────────────────╯"
+"╰─────────── > value • * iterate • ^ parent • } wrap • ]/[ siblings ───────────╯"
 "╭ Search ─────────────────────────────────────────────────────────────   1/2   ╮"
 "│alice                                                                         │"
 "╰──── Enter Confirm • > value • * iterate • ^ parent • } wrap • Esc Close ─────╯"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__search_tests__snapshot_search_with_highlighted_matches.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__search_tests__snapshot_search_with_highlighted_matches.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/search_tests.rs
+assertion_line: 109
 expression: output
 ---
 "╭ Array [3 objects]  · .[0].email ────────────────────────────── L1-12/12 (0%) ╮"
@@ -21,7 +22,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰────────────────── > value • * iterate • ^ parent • } wrap ───────────────────╯"
+"╰─────────── > value • * iterate • ^ parent • } wrap • ]/[ siblings ───────────╯"
 "╭ Search ─────────────────────────────────────────────────────────────   2/3   ╮"
 "│alice                                                                         │"
 "╰──── Enter Confirm • > value • * iterate • ^ parent • } wrap • Esc Close ─────╯"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__search_tests__snapshot_search_with_horizontal_scroll.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__search_tests__snapshot_search_with_horizontal_scroll.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/search_tests.rs
+assertion_line: 184
 expression: output
 ---
 "╭ Object  · .very_long_field ───────────────────────────────────── L1-4/4 (0%) ╮"
@@ -21,7 +22,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰/Prev • Enter Next • > value • * iterate • ^ parent • } wrap • Ctrl+F Edit • E╯"
+"╰ Enter Next • > value • * iterate • ^ parent • } wrap • ]/[ siblings • Ctrl+F ╯"
 "╭ Search ──────────────────────────────────────────────────────────────────────╮"
 "│match_here                                                                    │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_empty.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_empty.snap
@@ -1,5 +1,6 @@
 ---
 source: src/input/input_render_tests.rs
+assertion_line: 77
 expression: output
 ---
 "╭ Object  · . ──────────────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -21,7 +22,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ sibl╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_insert_mode.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_insert_mode.snap
@@ -1,5 +1,6 @@
 ---
 source: src/input/input_render_tests.rs
+assertion_line: 54
 expression: output
 ---
 "╭ Object  · . ──────────────────────────────────────────────────── L1-1/1 (0%) ╮"
@@ -21,7 +22,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ sibl╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_long_query.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_long_query.snap
@@ -1,5 +1,6 @@
 ---
 source: src/input/input_render_tests.rs
+assertion_line: 94
 expression: output
 ---
 "╭ Object  · . ──────────────────────────────────────────────────── L1-1/1 (0%) ╮"
@@ -21,7 +22,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ sibl╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.users | map(select(.name == "Alice")) | .[0].name                            │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_normal_mode.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_normal_mode.snap
@@ -1,5 +1,6 @@
 ---
 source: src/input/input_render_tests.rs
+assertion_line: 67
 expression: output
 ---
 "╭ Object  · . ──────────────────────────────────────────────────── L1-1/1 (0%) ╮"
@@ -21,7 +22,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ sibl╯"
 "╭ Query [NORMAL] (press 'i' to edit) ───────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_normal_mode_with_syntax_error.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_normal_mode_with_syntax_error.snap
@@ -1,5 +1,6 @@
 ---
 source: src/input/input_render_tests.rs
+assertion_line: 147
 expression: output
 ---
 "╭   ⚠ Syntax Error   Object | Showing last successful result ───── L1-3/3 (0%) ╮"
@@ -21,7 +22,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ sibl╯"
 "╭ Query [NORMAL] (press 'i' to edit) ───────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid[                                                                     │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_with_syntax_error.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_with_syntax_error.snap
@@ -1,5 +1,6 @@
 ---
 source: src/input/input_render_tests.rs
+assertion_line: 106
 expression: output
 ---
 "╭   ⚠ Syntax Error   Object | Showing last successful result ───── L1-3/3 (0%) ╮"
@@ -21,7 +22,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ sibl╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid[                                                                     │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_with_syntax_error_mode_text_red.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_with_syntax_error_mode_text_red.snap
@@ -1,5 +1,6 @@
 ---
 source: src/input/input_render_tests.rs
+assertion_line: 133
 expression: output
 ---
 "╭   ⚠ Syntax Error   Object | Showing last successful result ───── L1-3/3 (0%) ╮"
@@ -21,7 +22,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ sibl╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid[                                                                     │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"

--- a/src/json_path.rs
+++ b/src/json_path.rs
@@ -242,6 +242,102 @@ pub fn parse_jq_path(input: &str) -> Option<JsonPath> {
     Some(path)
 }
 
+/// Direction for sibling navigation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SiblingDir {
+    Prev,
+    Next,
+}
+
+/// Result of [`sibling_at`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum SiblingOutcome {
+    /// New path with the last step replaced by the chosen sibling.
+    Sibling(JsonPath),
+    /// `path` is empty: the cursor is at the root, so there's no parent
+    /// container whose siblings we can enumerate.
+    NoParent,
+    /// The parent has a single child — walking would be a no-op. Caller
+    /// surfaces a notification so repeated presses don't silently cycle.
+    Single,
+    /// The path doesn't address a real position in `value` (e.g., a key
+    /// step where the parent is an array, or vice-versa). Treated like
+    /// "no sibling" — the cursor row resolved to a path that no longer
+    /// lines up with the parsed value.
+    Invalid,
+}
+
+/// Resolve the path of the previous or next sibling of the value addressed
+/// by `path` inside `value`. Wraps at container boundaries: `Next` from the
+/// last child returns the first; `Prev` from the first child returns the
+/// last.
+///
+/// O(depth + parent_arity). Walks `path.steps[..len-1]` once to find the
+/// parent container, then does a single pass to locate the current step
+/// and pick its neighbor. Allocates only the returned path.
+pub fn sibling_at(value: &Value, path: &JsonPath, dir: SiblingDir) -> SiblingOutcome {
+    let steps = path.steps();
+    if steps.is_empty() {
+        return SiblingOutcome::NoParent;
+    }
+    let parent = match resolve_value(value, &steps[..steps.len() - 1]) {
+        Some(v) => v,
+        None => return SiblingOutcome::Invalid,
+    };
+    let last = steps.last().unwrap();
+    let new_last = match (parent, last) {
+        (Value::Object(map), JsonPathStep::Key(k)) => {
+            if map.len() <= 1 {
+                return SiblingOutcome::Single;
+            }
+            let idx = match map.keys().position(|key| key == k) {
+                Some(i) => i,
+                None => return SiblingOutcome::Invalid,
+            };
+            let neighbor_idx = wrapping_neighbor(idx, map.len(), dir);
+            let neighbor_key = map.keys().nth(neighbor_idx).unwrap().clone();
+            JsonPathStep::Key(neighbor_key)
+        }
+        (Value::Array(arr), JsonPathStep::Index(i)) => {
+            if arr.len() <= 1 {
+                return SiblingOutcome::Single;
+            }
+            if *i >= arr.len() {
+                return SiblingOutcome::Invalid;
+            }
+            let neighbor_idx = wrapping_neighbor(*i, arr.len(), dir);
+            JsonPathStep::Index(neighbor_idx)
+        }
+        _ => return SiblingOutcome::Invalid,
+    };
+    let mut new_path = JsonPath::new();
+    new_path.steps.extend_from_slice(&steps[..steps.len() - 1]);
+    new_path.steps.push(new_last);
+    SiblingOutcome::Sibling(new_path)
+}
+
+fn wrapping_neighbor(idx: usize, len: usize, dir: SiblingDir) -> usize {
+    debug_assert!(len > 0 && idx < len);
+    match dir {
+        SiblingDir::Next => (idx + 1) % len,
+        SiblingDir::Prev => (idx + len - 1) % len,
+    }
+}
+
+/// Walk `value` along `steps`, returning the addressed sub-value. Returns
+/// `None` if any step doesn't fit the current container's shape.
+fn resolve_value<'a>(value: &'a Value, steps: &[JsonPathStep]) -> Option<&'a Value> {
+    let mut cur = value;
+    for step in steps {
+        cur = match (cur, step) {
+            (Value::Object(map), JsonPathStep::Key(k)) => map.get(k)?,
+            (Value::Array(arr), JsonPathStep::Index(i)) => arr.get(*i)?,
+            _ => return None,
+        };
+    }
+    Some(cur)
+}
+
 /// Locate the path of the value pretty-printed on a given line.
 ///
 /// The line layout matches `serde_json::to_string_pretty` with the default
@@ -257,9 +353,9 @@ pub fn path_at_line(value: &Value, target_line: usize) -> Option<JsonPath> {
 
 /// Count how many lines `serde_json::to_string_pretty` would emit for `value`.
 ///
-/// Public for future stream-aware path lookups; currently consumed only by
-/// the test suite to lock the walker's line-counting invariant against
-/// `serde_json` updates.
+/// Currently consumed only by the test suite to lock the walker's
+/// line-counting invariant against `serde_json` updates; kept public so
+/// future stream-aware path lookups can reach for the same counter.
 #[allow(dead_code)]
 pub fn pretty_line_count(value: &Value) -> usize {
     let mut counter = LineCounter::default();
@@ -267,13 +363,56 @@ pub fn pretty_line_count(value: &Value) -> usize {
     counter.lines + 1
 }
 
+/// Inverse of [`path_at_line`]: locate the line where `path` is rendered.
+///
+/// Returns `None` if `path` doesn't address a real position in `value`.
+/// The root path renders at line 0 (the opening brace of the document).
+/// Walks `O(depth + sum_of_prev_sibling_pretty_line_counts)` — the same
+/// budget [`path_at_line`] uses in the opposite direction.
+pub fn line_at_path(value: &Value, path: &JsonPath) -> Option<usize> {
+    let mut cursor = 0usize;
+    let mut current = value;
+    for step in path.steps() {
+        cursor += 1;
+        match (current, step) {
+            (Value::Object(map), JsonPathStep::Key(k)) => {
+                let mut found = false;
+                for (key, child) in map {
+                    if key == k {
+                        current = child;
+                        found = true;
+                        break;
+                    }
+                    let mut counter = LineCounter::default();
+                    counter.count(child);
+                    cursor += counter.lines + 1;
+                }
+                if !found {
+                    return None;
+                }
+            }
+            (Value::Array(arr), JsonPathStep::Index(i)) => {
+                if *i >= arr.len() {
+                    return None;
+                }
+                for prev in arr.iter().take(*i) {
+                    let mut counter = LineCounter::default();
+                    counter.count(prev);
+                    cursor += counter.lines + 1;
+                }
+                current = &arr[*i];
+            }
+            _ => return None,
+        }
+    }
+    Some(cursor)
+}
+
 #[derive(Default)]
-#[allow(dead_code)]
 struct LineCounter {
     lines: usize,
 }
 
-#[allow(dead_code)]
 impl LineCounter {
     fn count(&mut self, value: &Value) {
         match value {

--- a/src/json_path_tests.rs
+++ b/src/json_path_tests.rs
@@ -402,3 +402,407 @@ fn path_at_line_respects_input_order() {
     assert_eq!(path_at_line(&v, 2).unwrap().to_jq(), ".a");
     assert_eq!(path_at_line(&v, 3).unwrap().to_jq(), ".m");
 }
+
+mod line_at_path_tests {
+    use super::*;
+
+    #[test]
+    fn root_path_is_line_zero() {
+        let v = json!({"a": 1, "b": 2});
+        assert_eq!(line_at_path(&v, &JsonPath::new()), Some(0));
+    }
+
+    #[test]
+    fn scalar_root_is_line_zero() {
+        let v = json!(42);
+        assert_eq!(line_at_path(&v, &JsonPath::new()), Some(0));
+    }
+
+    #[test]
+    fn object_key_lines_are_walked_in_input_order() {
+        let v: Value = serde_json::from_str(r#"{"z": 1, "a": 2, "m": 3}"#).unwrap();
+        let mut p = JsonPath::new();
+        p.push_key("z");
+        assert_eq!(line_at_path(&v, &p), Some(1));
+        let mut p = JsonPath::new();
+        p.push_key("a");
+        assert_eq!(line_at_path(&v, &p), Some(2));
+        let mut p = JsonPath::new();
+        p.push_key("m");
+        assert_eq!(line_at_path(&v, &p), Some(3));
+    }
+
+    #[test]
+    fn array_index_lines_are_walked() {
+        let v = json!([10, 20, 30]);
+        for i in 0..3 {
+            let mut p = JsonPath::new();
+            p.push_index(i);
+            assert_eq!(line_at_path(&v, &p), Some(i + 1));
+        }
+    }
+
+    #[test]
+    fn nested_object_lines_account_for_prior_siblings_recursively() {
+        let v = json!({"users": [{"name": "alice"}, {"name": "bob"}]});
+        let mut p = JsonPath::new();
+        p.push_key("users");
+        assert_eq!(line_at_path(&v, &p), Some(1));
+        p.push_index(0);
+        assert_eq!(line_at_path(&v, &p), Some(2));
+        p.push_key("name");
+        assert_eq!(line_at_path(&v, &p), Some(3));
+        let mut p2 = JsonPath::new();
+        p2.push_key("users");
+        p2.push_index(1);
+        assert_eq!(line_at_path(&v, &p2), Some(5));
+        p2.push_key("name");
+        assert_eq!(line_at_path(&v, &p2), Some(6));
+    }
+
+    #[test]
+    fn missing_key_returns_none() {
+        let v = json!({"a": 1});
+        let mut p = JsonPath::new();
+        p.push_key("missing");
+        assert_eq!(line_at_path(&v, &p), None);
+    }
+
+    #[test]
+    fn out_of_bounds_index_returns_none() {
+        let v = json!([1, 2]);
+        let mut p = JsonPath::new();
+        p.push_index(5);
+        assert_eq!(line_at_path(&v, &p), None);
+    }
+
+    #[test]
+    fn type_mismatch_returns_none() {
+        let v = json!({"a": 1});
+        let mut p = JsonPath::new();
+        p.push_index(0);
+        assert_eq!(line_at_path(&v, &p), None);
+    }
+
+    #[test]
+    fn round_trip_with_path_at_line_for_every_row() {
+        // For every line in the pretty-printed value, path_at_line(line)
+        // must return a path whose line_at_path lands at the same line
+        // (modulo closing-bracket lines, which map back to the parent).
+        let v = json!({
+            "users": [
+                {"name": "alice", "age": 30},
+                {"name": "bob", "age": 25},
+            ],
+            "meta": {"count": 2}
+        });
+        let pretty = serde_json::to_string_pretty(&v).unwrap();
+        for (i, _) in pretty.lines().enumerate() {
+            let path = path_at_line(&v, i).expect("path exists");
+            let back = line_at_path(&v, &path).expect("line exists");
+            // Closing brackets map back to the parent, so the round-trip
+            // is allowed to land on or before the original line.
+            assert!(
+                back <= i,
+                "line {} path {:?} mapped back to {}",
+                i,
+                path,
+                back
+            );
+        }
+    }
+
+    #[test]
+    fn special_keys_are_resolved() {
+        let v: Value = serde_json::from_str(r#"{"foo-bar": {"nested": 1}}"#).unwrap();
+        let mut p = JsonPath::new();
+        p.push_key("foo-bar");
+        assert_eq!(line_at_path(&v, &p), Some(1));
+        p.push_key("nested");
+        assert_eq!(line_at_path(&v, &p), Some(2));
+    }
+
+    #[test]
+    fn array_of_objects_indices_land_on_open_brace_lines() {
+        // Pretty layout for [{"a":1},{"b":2}]:
+        // 0: [
+        // 1:   {     ← .[0]
+        // 2:     "a": 1
+        // 3:   },
+        // 4:   {     ← .[1]
+        // 5:     "b": 2
+        // 6:   }
+        // 7: ]
+        let v = json!([{"a": 1}, {"b": 2}]);
+        let mut p0 = JsonPath::new();
+        p0.push_index(0);
+        assert_eq!(line_at_path(&v, &p0), Some(1));
+        let mut p1 = JsonPath::new();
+        p1.push_index(1);
+        assert_eq!(line_at_path(&v, &p1), Some(4));
+    }
+}
+
+mod sibling_at_tests {
+    use super::*;
+
+    fn key(k: &str) -> JsonPath {
+        let mut p = JsonPath::new();
+        p.push_key(k);
+        p
+    }
+
+    fn keys(parts: &[&str]) -> JsonPath {
+        let mut p = JsonPath::new();
+        for k in parts {
+            p.push_key(*k);
+        }
+        p
+    }
+
+    fn idx(i: usize) -> JsonPath {
+        let mut p = JsonPath::new();
+        p.push_index(i);
+        p
+    }
+
+    fn key_then_idx(k: &str, i: usize) -> JsonPath {
+        let mut p = JsonPath::new();
+        p.push_key(k);
+        p.push_index(i);
+        p
+    }
+
+    fn assert_sibling(out: SiblingOutcome, expected: &str) {
+        match out {
+            SiblingOutcome::Sibling(p) => assert_eq!(p.to_jq(), expected),
+            other => panic!("expected Sibling({}), got {:?}", expected, other),
+        }
+    }
+
+    #[test]
+    fn next_walks_object_keys_in_input_order() {
+        let v: Value = serde_json::from_str(r#"{"z": 1, "a": 2, "m": 3}"#).unwrap();
+        assert_sibling(sibling_at(&v, &key("z"), SiblingDir::Next), ".a");
+        assert_sibling(sibling_at(&v, &key("a"), SiblingDir::Next), ".m");
+    }
+
+    #[test]
+    fn prev_walks_object_keys_in_reverse_input_order() {
+        let v: Value = serde_json::from_str(r#"{"z": 1, "a": 2, "m": 3}"#).unwrap();
+        assert_sibling(sibling_at(&v, &key("m"), SiblingDir::Prev), ".a");
+        assert_sibling(sibling_at(&v, &key("a"), SiblingDir::Prev), ".z");
+    }
+
+    #[test]
+    fn next_wraps_at_last_object_key() {
+        let v: Value = serde_json::from_str(r#"{"z": 1, "a": 2, "m": 3}"#).unwrap();
+        assert_sibling(sibling_at(&v, &key("m"), SiblingDir::Next), ".z");
+    }
+
+    #[test]
+    fn prev_wraps_at_first_object_key() {
+        let v: Value = serde_json::from_str(r#"{"z": 1, "a": 2, "m": 3}"#).unwrap();
+        assert_sibling(sibling_at(&v, &key("z"), SiblingDir::Prev), ".m");
+    }
+
+    #[test]
+    fn next_walks_array_indices() {
+        let v = json!([10, 20, 30]);
+        assert_sibling(sibling_at(&v, &idx(0), SiblingDir::Next), ".[1]");
+        assert_sibling(sibling_at(&v, &idx(1), SiblingDir::Next), ".[2]");
+    }
+
+    #[test]
+    fn prev_walks_array_indices() {
+        let v = json!([10, 20, 30]);
+        assert_sibling(sibling_at(&v, &idx(2), SiblingDir::Prev), ".[1]");
+        assert_sibling(sibling_at(&v, &idx(1), SiblingDir::Prev), ".[0]");
+    }
+
+    #[test]
+    fn next_wraps_at_last_array_index() {
+        let v = json!([10, 20, 30]);
+        assert_sibling(sibling_at(&v, &idx(2), SiblingDir::Next), ".[0]");
+    }
+
+    #[test]
+    fn prev_wraps_at_first_array_index() {
+        let v = json!([10, 20, 30]);
+        assert_sibling(sibling_at(&v, &idx(0), SiblingDir::Prev), ".[2]");
+    }
+
+    #[test]
+    fn root_path_returns_no_parent() {
+        let v = json!({"a": 1});
+        assert_eq!(
+            sibling_at(&v, &JsonPath::new(), SiblingDir::Next),
+            SiblingOutcome::NoParent
+        );
+        assert_eq!(
+            sibling_at(&v, &JsonPath::new(), SiblingDir::Prev),
+            SiblingOutcome::NoParent
+        );
+    }
+
+    #[test]
+    fn single_object_child_returns_single() {
+        let v = json!({"only": 1});
+        assert_eq!(
+            sibling_at(&v, &key("only"), SiblingDir::Next),
+            SiblingOutcome::Single
+        );
+        assert_eq!(
+            sibling_at(&v, &key("only"), SiblingDir::Prev),
+            SiblingOutcome::Single
+        );
+    }
+
+    #[test]
+    fn single_array_element_returns_single() {
+        let v = json!([42]);
+        assert_eq!(
+            sibling_at(&v, &idx(0), SiblingDir::Next),
+            SiblingOutcome::Single
+        );
+        assert_eq!(
+            sibling_at(&v, &idx(0), SiblingDir::Prev),
+            SiblingOutcome::Single
+        );
+    }
+
+    #[test]
+    fn key_step_with_array_parent_is_invalid() {
+        let v = json!([1, 2, 3]);
+        assert_eq!(
+            sibling_at(&v, &key("foo"), SiblingDir::Next),
+            SiblingOutcome::Invalid
+        );
+    }
+
+    #[test]
+    fn index_step_with_object_parent_is_invalid() {
+        let v = json!({"a": 1, "b": 2});
+        assert_eq!(
+            sibling_at(&v, &idx(0), SiblingDir::Next),
+            SiblingOutcome::Invalid
+        );
+    }
+
+    #[test]
+    fn out_of_bounds_array_index_is_invalid() {
+        let v = json!([1, 2]);
+        assert_eq!(
+            sibling_at(&v, &idx(5), SiblingDir::Next),
+            SiblingOutcome::Invalid
+        );
+    }
+
+    #[test]
+    fn missing_object_key_is_invalid() {
+        let v = json!({"a": 1, "b": 2});
+        assert_eq!(
+            sibling_at(&v, &key("missing"), SiblingDir::Next),
+            SiblingOutcome::Invalid
+        );
+    }
+
+    #[test]
+    fn nested_array_in_object_walks_inner_siblings() {
+        let v = json!({"users": [{"name": "alice"}, {"name": "bob"}, {"name": "carol"}]});
+        assert_sibling(
+            sibling_at(&v, &key_then_idx("users", 0), SiblingDir::Next),
+            ".users[1]",
+        );
+        assert_sibling(
+            sibling_at(&v, &key_then_idx("users", 2), SiblingDir::Next),
+            ".users[0]",
+        );
+        assert_sibling(
+            sibling_at(&v, &key_then_idx("users", 0), SiblingDir::Prev),
+            ".users[2]",
+        );
+    }
+
+    #[test]
+    fn deeply_nested_object_keys_walk_correctly() {
+        let v = json!({"outer": {"a": 1, "b": 2, "c": 3}});
+        assert_sibling(
+            sibling_at(&v, &keys(&["outer", "a"]), SiblingDir::Next),
+            ".outer.b",
+        );
+        assert_sibling(
+            sibling_at(&v, &keys(&["outer", "c"]), SiblingDir::Next),
+            ".outer.a",
+        );
+    }
+
+    #[test]
+    fn special_chars_in_sibling_key_emit_bracket_notation() {
+        let v: Value = serde_json::from_str(r#"{"normal": 1, "foo-bar": 2, "café": 3}"#).unwrap();
+        assert_sibling(
+            sibling_at(&v, &key("normal"), SiblingDir::Next),
+            ".[\"foo-bar\"]",
+        );
+        assert_sibling(
+            sibling_at(&v, &key("foo-bar"), SiblingDir::Next),
+            ".[\"café\"]",
+        );
+        assert_sibling(sibling_at(&v, &key("café"), SiblingDir::Next), ".normal");
+    }
+
+    #[test]
+    fn invalid_then_valid_step_in_path_is_invalid() {
+        let v = json!({"users": [{"name": "alice"}]});
+        let mut p = JsonPath::new();
+        p.push_index(0);
+        p.push_key("name");
+        assert_eq!(
+            sibling_at(&v, &p, SiblingDir::Next),
+            SiblingOutcome::Invalid
+        );
+    }
+
+    #[test]
+    fn next_then_prev_round_trips_in_object() {
+        let v: Value = serde_json::from_str(r#"{"a": 1, "b": 2, "c": 3}"#).unwrap();
+        let next = match sibling_at(&v, &key("b"), SiblingDir::Next) {
+            SiblingOutcome::Sibling(p) => p,
+            other => panic!("{:?}", other),
+        };
+        assert_eq!(next.to_jq(), ".c");
+        let back = match sibling_at(&v, &next, SiblingDir::Prev) {
+            SiblingOutcome::Sibling(p) => p,
+            other => panic!("{:?}", other),
+        };
+        assert_eq!(back.to_jq(), ".b");
+    }
+
+    #[test]
+    fn next_then_prev_round_trips_with_wrap() {
+        let v: Value = serde_json::from_str(r#"{"a": 1, "b": 2, "c": 3}"#).unwrap();
+        let next = match sibling_at(&v, &key("c"), SiblingDir::Next) {
+            SiblingOutcome::Sibling(p) => p,
+            other => panic!("{:?}", other),
+        };
+        assert_eq!(next.to_jq(), ".a");
+        let back = match sibling_at(&v, &next, SiblingDir::Prev) {
+            SiblingOutcome::Sibling(p) => p,
+            other => panic!("{:?}", other),
+        };
+        assert_eq!(back.to_jq(), ".c");
+    }
+
+    #[test]
+    fn deep_nesting_does_not_blow_stack() {
+        let mut v = json!(0i64);
+        for _ in 0..200 {
+            v = json!({ "n": v });
+        }
+        let mut p = JsonPath::new();
+        for _ in 0..150 {
+            p.push_key("n");
+        }
+        assert_eq!(sibling_at(&v, &p, SiblingDir::Next), SiblingOutcome::Single);
+    }
+}

--- a/src/path_at_cursor_apply.rs
+++ b/src/path_at_cursor_apply.rs
@@ -18,7 +18,10 @@
 //! synthesized it via drill-in.
 
 use crate::app::App;
-use crate::json_path::{JsonPath, JsonPathStep, format_field_name, is_simple_jq_identifier};
+use crate::json_path::{
+    JsonPath, JsonPathStep, SiblingDir, SiblingOutcome, format_field_name, is_simple_jq_identifier,
+    sibling_at,
+};
 use crate::query_undo::ViewportState;
 
 /// Where to source the row whose path we apply on `>`.
@@ -68,6 +71,20 @@ pub enum StepOutOutcome {
     /// Trailing pipe segment isn't a recognizable jq path expression that
     /// our own renderer would emit. Don't touch the input.
     Unparseable,
+}
+
+/// Outcome of `apply_sibling_cursor`. Caller maps to a notification or
+/// scroll update.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SiblingCursorOutcome {
+    /// Cursor moved to the sibling row (line index).
+    Moved(u32),
+    /// Cursor was at the root row — no parent container.
+    AtRoot,
+    /// Couldn't resolve a path for the source row.
+    NoPath,
+    /// The parent has a single child, so walking would be a no-op.
+    NoSibling,
 }
 
 /// Resolve `source` to a jq path string and pipe-compose it onto the
@@ -137,6 +154,42 @@ pub fn apply_keep_kv(app: &mut App, source: PathSource) -> ApplyOutcome {
         format!("{} | {}", parent, wrap)
     };
     compose_and_apply(app, suffix, /* push_to_ring */ true)
+}
+
+/// `[` / `]` — locate the previous / next sibling of `source`'s path in
+/// the parent container and return the line where it renders. Pure
+/// resolution: does NOT touch the textarea, the undo ring, the cursor,
+/// or the scroll state. Caller is responsible for moving the cursor.
+///
+/// Wraps at container boundaries: `Next` from the last child returns the
+/// first; `Prev` from the first returns the last.
+pub fn apply_sibling_cursor(
+    app: &mut App,
+    source: PathSource,
+    dir: SiblingDir,
+) -> SiblingCursorOutcome {
+    let path = match resolve_path(app, source) {
+        Some(p) => p,
+        None => return SiblingCursorOutcome::NoPath,
+    };
+    let parsed = match app
+        .query
+        .as_ref()
+        .and_then(|qs| qs.last_successful_result_parsed.clone())
+    {
+        Some(v) => v,
+        None => return SiblingCursorOutcome::NoPath,
+    };
+    let new_path = match sibling_at(parsed.as_ref(), &path, dir) {
+        SiblingOutcome::Sibling(p) => p,
+        SiblingOutcome::NoParent => return SiblingCursorOutcome::AtRoot,
+        SiblingOutcome::Single => return SiblingCursorOutcome::NoSibling,
+        SiblingOutcome::Invalid => return SiblingCursorOutcome::NoPath,
+    };
+    match crate::json_path::line_at_path(parsed.as_ref(), &new_path) {
+        Some(line) => SiblingCursorOutcome::Moved(line as u32),
+        None => SiblingCursorOutcome::NoPath,
+    }
 }
 
 /// Shared compose+rewrite logic. Returns `AtRoot` when the path collapses

--- a/src/path_at_cursor_apply_tests.rs
+++ b/src/path_at_cursor_apply_tests.rs
@@ -404,3 +404,215 @@ fn step_out_chain_walks_back_to_root() {
     let outcome = apply_step_out(&mut app);
     assert_eq!(outcome, StepOutOutcome::AtRoot);
 }
+
+// ----- sibling (`[` / `]`) — pure cursor movement -----
+
+#[test]
+fn sibling_next_returns_next_object_key_line() {
+    let mut app = test_app(r#"{"a": 1, "b": 2, "c": 3}"#);
+    place_cursor(&mut app, 1); // .a
+
+    let outcome = apply_sibling_cursor(&mut app, PathSource::CursorRow, SiblingDir::Next);
+
+    assert_eq!(outcome, SiblingCursorOutcome::Moved(2));
+}
+
+#[test]
+fn sibling_prev_returns_prev_object_key_line() {
+    let mut app = test_app(r#"{"a": 1, "b": 2, "c": 3}"#);
+    place_cursor(&mut app, 2); // .b
+
+    let outcome = apply_sibling_cursor(&mut app, PathSource::CursorRow, SiblingDir::Prev);
+
+    assert_eq!(outcome, SiblingCursorOutcome::Moved(1));
+}
+
+#[test]
+fn sibling_next_returns_array_index_line() {
+    let mut app = test_app(r#"[10, 20, 30]"#);
+    place_cursor(&mut app, 1); // .[0]
+
+    let outcome = apply_sibling_cursor(&mut app, PathSource::CursorRow, SiblingDir::Next);
+
+    assert_eq!(outcome, SiblingCursorOutcome::Moved(2));
+}
+
+#[test]
+fn sibling_next_wraps_at_last_object_key() {
+    let mut app = test_app(r#"{"a": 1, "b": 2, "c": 3}"#);
+    place_cursor(&mut app, 3); // .c
+
+    let outcome = apply_sibling_cursor(&mut app, PathSource::CursorRow, SiblingDir::Next);
+
+    assert_eq!(outcome, SiblingCursorOutcome::Moved(1));
+}
+
+#[test]
+fn sibling_prev_wraps_at_first_array_index() {
+    let mut app = test_app(r#"[10, 20, 30]"#);
+    place_cursor(&mut app, 1); // .[0]
+
+    let outcome = apply_sibling_cursor(&mut app, PathSource::CursorRow, SiblingDir::Prev);
+
+    assert_eq!(outcome, SiblingCursorOutcome::Moved(3));
+}
+
+#[test]
+fn sibling_does_not_modify_query_or_undo_ring() {
+    let mut app = test_app(r#"{"a": 1, "b": 2}"#);
+    app.input.textarea.insert_str(".untouched");
+    place_cursor(&mut app, 1);
+
+    apply_sibling_cursor(&mut app, PathSource::CursorRow, SiblingDir::Next);
+
+    assert_eq!(
+        app.input.query(),
+        ".untouched",
+        "sibling must not rewrite the textarea"
+    );
+    assert!(
+        app.query_undo.is_empty(),
+        "sibling must not push to the undo ring"
+    );
+    assert!(
+        !app.debouncer.has_pending(),
+        "sibling must not schedule a query re-run"
+    );
+}
+
+#[test]
+fn sibling_at_root_returns_at_root() {
+    let mut app = test_app(r#"{"a": 1}"#);
+    place_cursor(&mut app, 0); // root row
+
+    let outcome = apply_sibling_cursor(&mut app, PathSource::CursorRow, SiblingDir::Next);
+
+    assert_eq!(outcome, SiblingCursorOutcome::AtRoot);
+}
+
+#[test]
+fn sibling_with_single_child_returns_no_sibling() {
+    let mut app = test_app(r#"{"only": 1}"#);
+    place_cursor(&mut app, 1); // .only
+
+    let outcome = apply_sibling_cursor(&mut app, PathSource::CursorRow, SiblingDir::Next);
+
+    assert_eq!(outcome, SiblingCursorOutcome::NoSibling);
+}
+
+#[test]
+fn sibling_no_path_when_no_parsed_result() {
+    let mut app = test_app(r#"{"a": 1, "b": 2}"#);
+    place_cursor(&mut app, 1);
+    if let Some(qs) = app.query.as_mut() {
+        qs.last_successful_result_parsed = None;
+    }
+
+    let outcome = apply_sibling_cursor(&mut app, PathSource::CursorRow, SiblingDir::Next);
+
+    assert_eq!(outcome, SiblingCursorOutcome::NoPath);
+}
+
+#[test]
+fn sibling_resolves_nested_array_element_lines() {
+    let mut app = test_app(r#"{"users": [{"name": "alice"}, {"name": "bob"}]}"#);
+    // The pretty layout:
+    // 0: {
+    // 1:   "users": [
+    // 2:     {
+    // 3:       "name": "alice"
+    // 4:     },
+    // 5:     {
+    // 6:       "name": "bob"
+    // 7:     }
+    // ...
+    place_cursor(&mut app, 2); // .users[0]
+
+    let outcome = apply_sibling_cursor(&mut app, PathSource::CursorRow, SiblingDir::Next);
+
+    assert_eq!(outcome, SiblingCursorOutcome::Moved(5));
+}
+
+#[test]
+fn sibling_round_trips_via_next_then_prev() {
+    let mut app = test_app(r#"{"a": 1, "b": 2, "c": 3}"#);
+    place_cursor(&mut app, 2); // .b
+
+    let next_line = match apply_sibling_cursor(&mut app, PathSource::CursorRow, SiblingDir::Next) {
+        SiblingCursorOutcome::Moved(line) => line,
+        other => panic!("{:?}", other),
+    };
+    assert_eq!(next_line, 3); // .c
+    place_cursor(&mut app, next_line);
+
+    let back_line = match apply_sibling_cursor(&mut app, PathSource::CursorRow, SiblingDir::Prev) {
+        SiblingCursorOutcome::Moved(line) => line,
+        other => panic!("{:?}", other),
+    };
+    assert_eq!(back_line, 2); // .b
+}
+
+#[test]
+fn sibling_with_explicit_match_row_uses_that_row() {
+    let mut app = test_app(r#"{"a": 1, "b": 2, "c": 3}"#);
+    place_cursor(&mut app, 0); // cursor at root, but...
+
+    let outcome = apply_sibling_cursor(&mut app, PathSource::Row(2), SiblingDir::Next);
+
+    // Row 2 is .b; sibling next is .c at line 3.
+    assert_eq!(outcome, SiblingCursorOutcome::Moved(3));
+}
+
+#[test]
+fn sibling_in_array_of_objects_cursor_on_open_brace_walks_to_next_open_brace() {
+    let mut app = test_app(r#"[{"a": 1}, {"b": 2}]"#);
+    place_cursor(&mut app, 1); // first `{` row → .[0]
+
+    let outcome = apply_sibling_cursor(&mut app, PathSource::CursorRow, SiblingDir::Next);
+
+    assert_eq!(
+        outcome,
+        SiblingCursorOutcome::Moved(4),
+        "cursor on .[0]'s `{{` should walk to .[1]'s `{{` row"
+    );
+}
+
+#[test]
+fn sibling_in_array_of_objects_cursor_on_close_brace_walks_to_next_open_brace() {
+    let mut app = test_app(r#"[{"a": 1}, {"b": 2}]"#);
+    place_cursor(&mut app, 3); // `},` row → also .[0] per path_at_line semantics
+
+    let outcome = apply_sibling_cursor(&mut app, PathSource::CursorRow, SiblingDir::Next);
+
+    assert_eq!(
+        outcome,
+        SiblingCursorOutcome::Moved(4),
+        "closing brace of .[0] still walks to .[1]'s open brace"
+    );
+}
+
+#[test]
+fn sibling_in_array_of_objects_cursor_on_inner_key_walks_inner_object_keys() {
+    let mut app = test_app(r#"[{"a": 1, "b": 2}, {"c": 3, "d": 4}]"#);
+    place_cursor(&mut app, 2); // .[0].a
+
+    let outcome = apply_sibling_cursor(&mut app, PathSource::CursorRow, SiblingDir::Next);
+
+    // Pretty layout:
+    // 0: [
+    // 1:   {
+    // 2:     "a": 1,   ← cursor here
+    // 3:     "b": 2    ← sibling next of .[0].a is .[0].b
+    // ...
+    assert_eq!(outcome, SiblingCursorOutcome::Moved(3));
+}
+
+#[test]
+fn sibling_walk_inside_object_with_special_keys() {
+    let mut app = test_app(r#"{"normal": 1, "foo-bar": 2}"#);
+    place_cursor(&mut app, 1); // .normal
+
+    let outcome = apply_sibling_cursor(&mut app, PathSource::CursorRow, SiblingDir::Next);
+
+    assert_eq!(outcome, SiblingCursorOutcome::Moved(2));
+}

--- a/src/results/results_events.rs
+++ b/src/results/results_events.rs
@@ -4,9 +4,10 @@ use crate::app::App;
 use crate::clipboard;
 use crate::editor::EditorMode;
 use crate::help::HelpTab;
+use crate::json_path::SiblingDir;
 use crate::path_at_cursor_apply::{
-    ApplyOutcome, PathSource, StepOutOutcome, UndoOutcome, apply_iterate, apply_keep_kv,
-    apply_path, apply_step_out, pop_undo,
+    ApplyOutcome, PathSource, SiblingCursorOutcome, StepOutOutcome, UndoOutcome, apply_iterate,
+    apply_keep_kv, apply_path, apply_sibling_cursor, apply_step_out, pop_undo,
 };
 
 pub fn handle_results_pane_key(app: &mut App, key: KeyEvent) {
@@ -136,6 +137,14 @@ pub fn handle_results_pane_key(app: &mut App, key: KeyEvent) {
             keep_kv(app, PathSource::CursorRow);
         }
 
+        KeyCode::Char('[') => {
+            sibling(app, PathSource::CursorRow, SiblingDir::Prev);
+        }
+
+        KeyCode::Char(']') => {
+            sibling(app, PathSource::CursorRow, SiblingDir::Next);
+        }
+
         _ => {}
     }
 }
@@ -172,6 +181,27 @@ pub(crate) fn iterate(app: &mut App, source: PathSource) {
 pub(crate) fn keep_kv(app: &mut App, source: PathSource) {
     let outcome = apply_keep_kv(app, source);
     report_apply_outcome(app, outcome);
+}
+
+/// `[` / `]` — move the results-pane cursor to the previous / next
+/// sibling row inside the parent container of `source`'s path. Pure
+/// cursor movement: does NOT touch the query, the textarea, or the undo
+/// ring. Wraps at container boundaries.
+pub(crate) fn sibling(app: &mut App, source: PathSource, dir: SiblingDir) {
+    match apply_sibling_cursor(app, source, dir) {
+        SiblingCursorOutcome::Moved(line) => {
+            let total = app.results_line_count_u32();
+            app.results_cursor.update_total_lines(total);
+            app.results_cursor.move_to_line(line);
+            app.results_scroll
+                .ensure_cursor_visible(app.results_cursor.cursor_line());
+        }
+        SiblingCursorOutcome::AtRoot => app.notification.show("Already at root"),
+        SiblingCursorOutcome::NoPath => app.notification.show("No path at cursor"),
+        SiblingCursorOutcome::NoSibling => {
+            app.notification.show("No sibling to navigate to");
+        }
+    }
 }
 
 /// `^` — drop one step from the trailing path segment of the current

--- a/src/results/results_events_tests.rs
+++ b/src/results/results_events_tests.rs
@@ -802,4 +802,136 @@ mod drill_tests {
             }
         }
     }
+
+    #[test]
+    fn next_sibling_chord_moves_cursor_to_next_key_row() {
+        let mut app = test_app(r#"{"a": 1, "b": 2, "c": 3}"#);
+        place(&mut app, 1); // .a
+
+        app.handle_key_event(key(KeyCode::Char(']')));
+
+        assert_eq!(app.results_cursor.cursor_line(), 2, "cursor at .b row");
+        assert_eq!(app.input.query(), "", "query is unchanged");
+        assert!(
+            app.query_undo.is_empty(),
+            "no undo snapshot for cursor move"
+        );
+    }
+
+    #[test]
+    fn prev_sibling_chord_moves_cursor_to_prev_key_row() {
+        let mut app = test_app(r#"{"a": 1, "b": 2, "c": 3}"#);
+        place(&mut app, 2); // .b
+
+        app.handle_key_event(key(KeyCode::Char('[')));
+
+        assert_eq!(app.results_cursor.cursor_line(), 1, "cursor at .a row");
+    }
+
+    #[test]
+    fn next_sibling_chord_wraps_at_last_key() {
+        let mut app = test_app(r#"{"a": 1, "b": 2, "c": 3}"#);
+        place(&mut app, 3); // .c
+
+        app.handle_key_event(key(KeyCode::Char(']')));
+
+        assert_eq!(app.results_cursor.cursor_line(), 1, "wraps to .a row");
+    }
+
+    #[test]
+    fn sibling_chord_in_array_of_objects_walks_brace_to_brace() {
+        // [{"a":1},{"b":2}] — pretty layout:
+        // 0: [
+        // 1:   {       ← .[0]
+        // 2:     "a": 1
+        // 3:   },
+        // 4:   {       ← .[1]
+        // 5:     "b": 2
+        // 6:   }
+        // 7: ]
+        let mut app = test_app(r#"[{"a": 1}, {"b": 2}]"#);
+        place(&mut app, 1);
+
+        app.handle_key_event(key(KeyCode::Char(']')));
+
+        assert_eq!(
+            app.results_cursor.cursor_line(),
+            4,
+            "cursor on .[0]'s {{ should walk to .[1]'s {{ row"
+        );
+        assert!(
+            app.notification.current_message().is_none()
+                || app.notification.current_message() == Some(""),
+            "no notification on a successful sibling walk"
+        );
+    }
+
+    #[test]
+    fn sibling_chord_walks_array_indices() {
+        let mut app = test_app(r#"[10, 20, 30]"#);
+        place(&mut app, 1); // .[0]
+
+        app.handle_key_event(key(KeyCode::Char(']')));
+        assert_eq!(app.results_cursor.cursor_line(), 2);
+        app.handle_key_event(key(KeyCode::Char(']')));
+        assert_eq!(app.results_cursor.cursor_line(), 3);
+        app.handle_key_event(key(KeyCode::Char(']')));
+        assert_eq!(app.results_cursor.cursor_line(), 1, "wraps");
+    }
+
+    #[test]
+    fn sibling_chord_at_root_notifies_already_at_root() {
+        let mut app = test_app(r#"{"a": 1}"#);
+        app.input.textarea.insert_str(".existing");
+        place(&mut app, 0);
+
+        app.handle_key_event(key(KeyCode::Char(']')));
+
+        assert_eq!(app.input.query(), ".existing", "query untouched");
+        assert_eq!(app.results_cursor.cursor_line(), 0, "cursor unchanged");
+        assert_eq!(app.notification.current_message(), Some("Already at root"));
+    }
+
+    #[test]
+    fn sibling_chord_with_single_child_notifies() {
+        let mut app = test_app(r#"{"only": 1}"#);
+        place(&mut app, 1);
+
+        app.handle_key_event(key(KeyCode::Char(']')));
+
+        assert_eq!(app.results_cursor.cursor_line(), 1, "cursor unchanged");
+        assert_eq!(
+            app.notification.current_message(),
+            Some("No sibling to navigate to")
+        );
+    }
+
+    #[test]
+    fn sibling_chord_does_not_touch_undo_ring() {
+        let mut app = test_app(r#"{"a": 1, "b": 2}"#);
+        place(&mut app, 1);
+
+        // Drill in first to push a real snapshot...
+        app.handle_key_event(key(KeyCode::Char('>')));
+        let ring_before = !app.query_undo.is_empty();
+        assert!(ring_before, "test guard: drill pushed a snapshot");
+
+        // ...then a sibling walk should not invalidate it.
+        app.handle_key_event(key(KeyCode::Char(']')));
+
+        assert!(
+            !app.query_undo.is_empty(),
+            "sibling walk must preserve the undo ring"
+        );
+    }
+
+    #[test]
+    fn sibling_chord_stays_on_results_pane() {
+        let mut app = test_app(r#"{"a": 1, "b": 2}"#);
+        place(&mut app, 1);
+
+        app.handle_key_event(key(KeyCode::Char(']')));
+
+        assert_eq!(app.focus, Focus::ResultsPane);
+    }
 }

--- a/src/results/results_render.rs
+++ b/src/results/results_render.rs
@@ -25,14 +25,19 @@ const PATH_AT_CURSOR_MIN_WIDTH: usize = 5;
 const PATH_AT_CURSOR_CHROME_WIDTH: usize = 4;
 
 /// Build the path-navigation chord segment shared by every bottom border
-/// that advertises `>` / `<` / `*` / `^` / `}`. The `<` slot only renders
-/// when the undo ring is non-empty so the hint never misleads.
+/// that advertises `>` / `<` / `*` / `^` / `}` / `]` / `[`. The `<` slot
+/// only renders when the undo ring is non-empty so the hint never misleads.
 fn path_chord_hints(can_undo: bool) -> Vec<(&'static str, &'static str)> {
     let mut hints: Vec<(&'static str, &'static str)> = vec![(">", "value")];
     if can_undo {
         hints.push(("<", "back"));
     }
-    hints.extend([("*", "iterate"), ("^", "parent"), ("}", "wrap")]);
+    hints.extend([
+        ("*", "iterate"),
+        ("^", "parent"),
+        ("}", "wrap"),
+        ("]/[", "siblings"),
+    ]);
     hints
 }
 

--- a/src/search/search_events.rs
+++ b/src/search/search_events.rs
@@ -1,7 +1,11 @@
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::app::{App, Focus};
-use crate::path_at_cursor_apply::{ApplyOutcome, PathSource, apply_iterate, apply_keep_kv};
+use crate::json_path::SiblingDir;
+use crate::path_at_cursor_apply::{
+    ApplyOutcome, PathSource, SiblingCursorOutcome, apply_iterate, apply_keep_kv,
+    apply_sibling_cursor,
+};
 use crate::results::results_events::{drill_back, handle_results_pane_key, step_out};
 
 #[path = "search_events/scroll.rs"]
@@ -124,6 +128,16 @@ pub fn handle_search_key(app: &mut App, key: KeyEvent) -> bool {
             true
         }
 
+        KeyCode::Char('[') => {
+            sibling_from_search(app, SiblingDir::Prev);
+            true
+        }
+
+        KeyCode::Char(']') => {
+            sibling_from_search(app, SiblingDir::Next);
+            true
+        }
+
         // Delegate navigation keys to results pane when confirmed
         _ if app.search.is_confirmed() => {
             handle_results_pane_key(app, key);
@@ -222,6 +236,30 @@ fn keep_kv_from_search(app: &mut App) {
         ApplyOutcome::NoPath => app.notification.show("No path at cursor"),
         ApplyOutcome::NoArrayToIterate => unreachable!("apply_keep_kv never returns this"),
         ApplyOutcome::NoKeyToWrap => app.notification.show("No key at cursor to wrap"),
+    }
+}
+
+/// `[` / `]` from search — move the results-pane cursor to the prev /
+/// next sibling row of the match row's path. Pure cursor movement: does
+/// NOT close the search overlay or modify the query.
+fn sibling_from_search(app: &mut App, dir: SiblingDir) {
+    let match_row = match resolve_match_row(app) {
+        Some(r) => r,
+        None => return,
+    };
+    match apply_sibling_cursor(app, PathSource::Row(match_row), dir) {
+        SiblingCursorOutcome::Moved(line) => {
+            let total = app.results_line_count_u32();
+            app.results_cursor.update_total_lines(total);
+            app.results_cursor.move_to_line(line);
+            app.results_scroll
+                .ensure_cursor_visible(app.results_cursor.cursor_line());
+        }
+        SiblingCursorOutcome::AtRoot => app.notification.show("Already at root"),
+        SiblingCursorOutcome::NoPath => app.notification.show("No path at cursor"),
+        SiblingCursorOutcome::NoSibling => {
+            app.notification.show("No sibling to navigate to");
+        }
     }
 }
 

--- a/src/search/search_events_tests/drill_tests.rs
+++ b/src/search/search_events_tests/drill_tests.rs
@@ -225,3 +225,109 @@ fn search_match_path_resolves_to_match_row_not_cursor() {
     assert_eq!(match_path, ".beta");
     assert_eq!(cursor_path, ".");
 }
+
+#[test]
+fn next_sibling_chord_moves_cursor_using_match_row() {
+    // Match is on .beta (row 2). Cursor sits at root row 0. `]` should
+    // move the cursor to .gamma (row 3) using the match row, not the
+    // cursor row.
+    let (mut app, _) = open_search_with_match(r#"{"alpha": 1, "beta": 2, "gamma": 3}"#, "beta");
+    let total = app.results_line_count_u32();
+    app.results_cursor.update_total_lines(total);
+    app.results_cursor.move_to_line(0);
+    let prior_query = app.input.query().to_string();
+
+    handle_search_key(&mut app, key(KeyCode::Char(']')));
+
+    assert_eq!(app.results_cursor.cursor_line(), 3, "cursor at .gamma row");
+    assert!(app.search.is_visible(), "search stays open on cursor move");
+    assert_eq!(app.input.query(), prior_query, "query is untouched");
+}
+
+#[test]
+fn prev_sibling_chord_moves_cursor_using_match_row() {
+    let (mut app, _) = open_search_with_match(r#"{"alpha": 1, "beta": 2, "gamma": 3}"#, "beta");
+    let total = app.results_line_count_u32();
+    app.results_cursor.update_total_lines(total);
+    app.results_cursor.move_to_line(0);
+
+    handle_search_key(&mut app, key(KeyCode::Char('[')));
+
+    assert_eq!(app.results_cursor.cursor_line(), 1, "cursor at .alpha row");
+    assert!(app.search.is_visible());
+}
+
+#[test]
+fn sibling_chord_in_search_with_no_match_notifies() {
+    let mut app = test_app(r#"{"a": 1, "b": 2}"#);
+    if let Some(qs) = app.query.as_mut() {
+        qs.execute(".");
+    }
+    open_search(&mut app);
+    app.search.search_textarea_mut().insert_str("missing");
+    app.search.update_matches("{\"a\": 1, \"b\": 2}");
+
+    handle_search_key(&mut app, key(KeyCode::Char(']')));
+
+    assert!(app.search.is_visible(), "stays open with no match");
+    assert_eq!(
+        app.notification.current_message(),
+        Some("No match to navigate to")
+    );
+}
+
+#[test]
+fn sibling_chord_in_search_at_root_keeps_search_open() {
+    let (mut app, _) = open_search_with_match(r#"42"#, "42");
+
+    handle_search_key(&mut app, key(KeyCode::Char(']')));
+
+    assert!(app.search.is_visible(), "stays open at root");
+    assert_eq!(app.notification.current_message(), Some("Already at root"));
+}
+
+#[test]
+fn sibling_chord_in_search_with_single_child_notifies() {
+    let (mut app, _) = open_search_with_match(r#"{"only": 42}"#, "42");
+
+    handle_search_key(&mut app, key(KeyCode::Char(']')));
+
+    assert!(app.search.is_visible(), "stays open on no-sibling");
+    assert_eq!(
+        app.notification.current_message(),
+        Some("No sibling to navigate to")
+    );
+}
+
+#[test]
+fn sibling_chord_does_not_leak_into_search_query() {
+    let (mut app, _) = open_search_with_match(r#"{"a": 1, "b": 2}"#, "1");
+    assert!(!app.search.is_confirmed());
+
+    handle_search_key(&mut app, key(KeyCode::Char(']')));
+
+    assert!(!app.search.query().contains(']'));
+}
+
+#[test]
+fn sibling_chord_works_in_search_confirmed_mode() {
+    let (mut app, _) = open_search_with_match(r#"{"a": 1, "b": 2, "c": 3}"#, "2");
+    handle_search_key(&mut app, key(KeyCode::Enter));
+    assert!(app.search.is_confirmed());
+
+    handle_search_key(&mut app, key(KeyCode::Char(']')));
+
+    assert_eq!(app.results_cursor.cursor_line(), 3, "cursor at .c row");
+    assert!(app.search.is_visible(), "stays open after sibling move");
+}
+
+#[test]
+fn sibling_chord_in_search_does_not_modify_query_or_undo_ring() {
+    let (mut app, _) = open_search_with_match(r#"{"a": 1, "b": 2}"#, "1");
+    let prior_query = app.input.query().to_string();
+
+    handle_search_key(&mut app, key(KeyCode::Char(']')));
+
+    assert_eq!(app.input.query(), prior_query);
+    assert!(app.query_undo.is_empty());
+}


### PR DESCRIPTION
## Summary
- New chords `]` (next sibling) and `[` (previous sibling) on the results pane and in search mode. Cursor-only movement: jumps to the sibling row inside the current parent container, wraps at boundaries, and leaves the query, textarea, and undo ring untouched. Soft no-ops at the root row and on single-child containers, with notifications.
- Backed by `sibling_at` (parent walk against parsed JSON, preserves `serde_json` insertion order) and a new `line_at_path` walker (inverse of `path_at_line`) so the chord maps a structural sibling back to its rendered row.
- Bottom-border hint extended: `> value · < back · * iterate · ^ parent · } wrap · ]/[ siblings`.

## Test plan
- [x] cargo test (3310 passed, 0 failed)
- [x] cargo build --release
- [x] cargo clippy --all-targets --all-features (zero warnings)
- [x] cargo fmt --all --check
- [x] Manual TUI validation — confirmed `]`/`[` move the cursor between siblings in objects and arrays, including arrays of objects (cursor on `{` hops to the next object's `{`), search-mode keeps the overlay open, `<` does not undo a sibling step.