### PR TITLE
feat(mouse): double-click drills into result rows and accepts autocomplete suggestions

### DIFF
--- a/docs/features/mouse.md
+++ b/docs/features/mouse.md
@@ -17,6 +17,7 @@ jiq has two main areas: the query input (where you type) and the output area (wh
 | Click | Input field | Position cursor at click location |
 | Click | Autocomplete | Highlight a suggestion |
 | Double-click | Autocomplete | Apply a suggestion |
+| Double-click | Output area row | Drill into the value on that row (same as <kbd>&gt;</kbd>) |
 | Click + drag | Output area | Select multiple lines |
 | Scroll wheel | Output area | Scroll vertically |
 | Scroll wheel | Input field | Scroll horizontally through long queries |

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -281,6 +281,7 @@ Case-insensitive.
 |:---|:---|
 | Click pane | Focus |
 | Click + drag (results) | Multi-line visual selection |
+| Double-click result row | Drill into value (same as <kbd>&gt;</kbd>) |
 | Mouse wheel | Vertical scroll |
 | Click suggestion | Select |
 | Double-click suggestion | Apply |

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,7 @@
 mod app_events;
 mod app_render;
 mod app_state;
+mod double_click;
 mod mouse_click;
 mod mouse_events;
 mod mouse_hover;

--- a/src/app/app_state.rs
+++ b/src/app/app_state.rs
@@ -70,6 +70,7 @@ pub struct App {
     pub needs_render: bool,
     pub layout_regions: LayoutRegions,
     pub array_sample_size: usize,
+    pub double_click: super::double_click::DoubleClickTracker,
 }
 
 impl App {
@@ -179,6 +180,7 @@ impl App {
             needs_render: true,
             layout_regions: LayoutRegions::new(),
             array_sample_size: config.autocomplete.array_sample_size,
+            double_click: super::double_click::DoubleClickTracker::new(),
         }
     }
 

--- a/src/app/double_click.rs
+++ b/src/app/double_click.rs
@@ -1,0 +1,87 @@
+//! Double-click detection.
+//!
+//! Crossterm has no native double-click event on Unix terminals — apps must
+//! buffer the previous click's position/time and decide on the next one.
+//! This module owns that detection so every consumer (results pane drill,
+//! autocomplete accept, future widgets) shares one well-tested primitive.
+//!
+//! Defaults match the prevailing TUI convention (zellij, alacritty): 400 ms
+//! threshold, hard-coded. State is reset on the first hover or scroll
+//! after a click, so an idle pointer can't accumulate a stale second click.
+
+use std::time::{Duration, Instant};
+
+use ratatui::crossterm::event::MouseEvent;
+
+use crate::layout::Region;
+
+const DOUBLE_CLICK_THRESHOLD: Duration = Duration::from_millis(400);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Granularity {
+    SameCell,
+    SameRow,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct LastClick {
+    instant: Instant,
+    col: u16,
+    row: u16,
+    region: Region,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DoubleClickTracker {
+    last: Option<LastClick>,
+}
+
+impl DoubleClickTracker {
+    pub fn new() -> Self {
+        Self { last: None }
+    }
+
+    /// Record this click and report whether it completes a double-click pair
+    /// against the previous click in the same `region` and within the
+    /// threshold. On a successful match, internal state is cleared so a
+    /// third click doesn't keep the streak going.
+    pub fn check_and_record(
+        &mut self,
+        mouse: MouseEvent,
+        region: Region,
+        granularity: Granularity,
+    ) -> bool {
+        let now = Instant::now();
+        let is_double = self
+            .last
+            .filter(|prev| prev.region == region)
+            .filter(|prev| now.duration_since(prev.instant) <= DOUBLE_CLICK_THRESHOLD)
+            .filter(|prev| match granularity {
+                Granularity::SameCell => prev.col == mouse.column && prev.row == mouse.row,
+                Granularity::SameRow => prev.row == mouse.row,
+            })
+            .is_some();
+
+        if is_double {
+            self.last = None;
+        } else {
+            self.last = Some(LastClick {
+                instant: now,
+                col: mouse.column,
+                row: mouse.row,
+                region,
+            });
+        }
+        is_double
+    }
+
+    /// Drop any pending click. Called on hover/scroll so an unrelated
+    /// pointer movement between two clicks invalidates the pair.
+    pub fn reset(&mut self) {
+        self.last = None;
+    }
+}
+
+#[cfg(test)]
+#[path = "double_click_tests.rs"]
+mod double_click_tests;

--- a/src/app/double_click_tests.rs
+++ b/src/app/double_click_tests.rs
@@ -1,0 +1,87 @@
+//! Tests for the shared double-click tracker.
+
+use std::thread::sleep;
+use std::time::Duration;
+
+use ratatui::crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+use crate::layout::Region;
+
+use super::{DoubleClickTracker, Granularity};
+
+fn click(col: u16, row: u16) -> MouseEvent {
+    MouseEvent {
+        kind: MouseEventKind::Down(MouseButton::Left),
+        column: col,
+        row,
+        modifiers: KeyModifiers::NONE,
+    }
+}
+
+#[test]
+fn first_click_is_never_a_double() {
+    let mut t = DoubleClickTracker::new();
+    assert!(!t.check_and_record(click(5, 10), Region::ResultsPane, Granularity::SameRow));
+}
+
+#[test]
+fn same_row_second_click_within_threshold_is_double() {
+    let mut t = DoubleClickTracker::new();
+    t.check_and_record(click(5, 10), Region::ResultsPane, Granularity::SameRow);
+    assert!(t.check_and_record(click(20, 10), Region::ResultsPane, Granularity::SameRow));
+}
+
+#[test]
+fn same_cell_requires_exact_column_match() {
+    let mut t = DoubleClickTracker::new();
+    t.check_and_record(click(5, 10), Region::Autocomplete, Granularity::SameCell);
+    assert!(
+        !t.check_and_record(click(6, 10), Region::Autocomplete, Granularity::SameCell),
+        "different column under SameCell must not pair"
+    );
+
+    let mut t = DoubleClickTracker::new();
+    t.check_and_record(click(5, 10), Region::Autocomplete, Granularity::SameCell);
+    assert!(t.check_and_record(click(5, 10), Region::Autocomplete, Granularity::SameCell));
+}
+
+#[test]
+fn different_row_under_same_row_granularity_does_not_pair() {
+    let mut t = DoubleClickTracker::new();
+    t.check_and_record(click(5, 10), Region::ResultsPane, Granularity::SameRow);
+    assert!(!t.check_and_record(click(5, 11), Region::ResultsPane, Granularity::SameRow));
+}
+
+#[test]
+fn region_change_breaks_the_pair() {
+    let mut t = DoubleClickTracker::new();
+    t.check_and_record(click(5, 10), Region::ResultsPane, Granularity::SameRow);
+    assert!(!t.check_and_record(click(5, 10), Region::Autocomplete, Granularity::SameRow));
+}
+
+#[test]
+fn second_click_past_threshold_does_not_pair() {
+    let mut t = DoubleClickTracker::new();
+    t.check_and_record(click(5, 10), Region::ResultsPane, Granularity::SameRow);
+    sleep(Duration::from_millis(420));
+    assert!(!t.check_and_record(click(5, 10), Region::ResultsPane, Granularity::SameRow));
+}
+
+#[test]
+fn successful_double_does_not_chain_into_triple() {
+    let mut t = DoubleClickTracker::new();
+    t.check_and_record(click(5, 10), Region::ResultsPane, Granularity::SameRow);
+    assert!(t.check_and_record(click(5, 10), Region::ResultsPane, Granularity::SameRow));
+    assert!(
+        !t.check_and_record(click(5, 10), Region::ResultsPane, Granularity::SameRow),
+        "third rapid click must not pair as another double-click"
+    );
+}
+
+#[test]
+fn reset_clears_pending_click() {
+    let mut t = DoubleClickTracker::new();
+    t.check_and_record(click(5, 10), Region::ResultsPane, Granularity::SameRow);
+    t.reset();
+    assert!(!t.check_and_record(click(5, 10), Region::ResultsPane, Granularity::SameRow));
+}

--- a/src/app/mouse_click.rs
+++ b/src/app/mouse_click.rs
@@ -5,9 +5,12 @@
 use ratatui::crossterm::event::MouseEvent;
 
 use super::app_state::{App, Focus};
+use super::double_click::Granularity;
 use crate::ai::ai_events;
 use crate::editor::EditorMode;
 use crate::layout::Region;
+use crate::path_at_cursor_apply::PathSource;
+use crate::results::results_events;
 use crate::snippets::SnippetMode;
 
 /// Handle left mouse button click for the given region
@@ -31,6 +34,7 @@ pub fn handle_click(app: &mut App, region: Option<Region>, mouse: MouseEvent) {
         Some(Region::InputField) => click_input_field(app, mouse),
         Some(Region::SearchBar) => click_search_bar(app),
         Some(Region::AiWindow) => click_ai_window(app, mouse),
+        Some(Region::Autocomplete) => click_autocomplete(app, mouse),
         Some(Region::SnippetList) => click_snippet_list(app, mouse),
         Some(Region::HelpPopup) => click_help_popup(app, mouse),
         Some(Region::HistoryPopup) => click_history_popup(app, mouse),
@@ -100,6 +104,47 @@ fn click_results_pane(app: &mut App, mouse: MouseEvent) {
 
     if clicked_line < app.results_cursor.total_lines() {
         app.results_cursor.click_select(clicked_line);
+    }
+
+    let is_double_click =
+        app.double_click
+            .check_and_record(mouse, Region::ResultsPane, Granularity::SameRow);
+    if is_double_click && clicked_line < app.results_cursor.total_lines() {
+        results_events::drill_in(app, PathSource::CursorRow);
+    }
+}
+
+fn click_autocomplete(app: &mut App, mouse: MouseEvent) {
+    if !app.autocomplete.is_visible() {
+        return;
+    }
+
+    let Some(rect) = app.layout_regions.autocomplete else {
+        return;
+    };
+
+    let inner_y = rect.y.saturating_add(1);
+    let inner_height = rect.height.saturating_sub(2);
+
+    if mouse.row < inner_y || mouse.row >= inner_y.saturating_add(inner_height) {
+        return;
+    }
+
+    let relative_y = mouse.row.saturating_sub(inner_y) as usize;
+    let visible_index = app.autocomplete.scroll_offset() + relative_y;
+    if visible_index >= app.autocomplete.suggestions().len() {
+        return;
+    }
+
+    app.autocomplete.set_selected_index(visible_index);
+
+    let is_double_click =
+        app.double_click
+            .check_and_record(mouse, Region::Autocomplete, Granularity::SameCell);
+    if is_double_click && let Some(suggestion) = app.autocomplete.selected().cloned() {
+        app.insert_autocomplete_suggestion(&suggestion);
+        app.debouncer.mark_executed();
+        app.update_tooltip();
     }
 }
 

--- a/src/app/mouse_click_tests.rs
+++ b/src/app/mouse_click_tests.rs
@@ -684,3 +684,105 @@ fn test_click_history_popup_closes_when_last_entry_deleted() {
     assert!(!app.history.is_visible());
     assert_eq!(app.history.total_count(), 0);
 }
+
+#[test]
+fn test_double_click_results_pane_drills_in() {
+    use crate::test_utils::test_helpers::{execute_query_and_wait, test_app};
+
+    let mut app = test_app(r#"{"a": {"b": 1}}"#);
+    app.input.textarea.insert_str(".");
+    execute_query_and_wait(&mut app);
+    let total = app.results_line_count_u32();
+    app.results_cursor.update_total_lines(total);
+    app.layout_regions.results_pane = Some(ratatui::layout::Rect::new(0, 0, 40, 10));
+
+    // First click positions the cursor on the inner-row 1 (the `"a"` row);
+    // second click within the threshold is the double-click that drills in.
+    let mouse = create_mouse_event(5, 2);
+    handle_click(&mut app, Some(Region::ResultsPane), mouse);
+    let query_before = app.input.query().to_string();
+    handle_click(&mut app, Some(Region::ResultsPane), mouse);
+
+    assert_ne!(
+        app.input.query(),
+        query_before,
+        "double-click on results row should pipe-compose the row's path onto the query"
+    );
+}
+
+#[test]
+fn test_single_click_results_pane_does_not_drill() {
+    use crate::test_utils::test_helpers::{execute_query_and_wait, test_app};
+
+    let mut app = test_app(r#"{"a": {"b": 1}}"#);
+    app.input.textarea.insert_str(".");
+    execute_query_and_wait(&mut app);
+    let total = app.results_line_count_u32();
+    app.results_cursor.update_total_lines(total);
+    app.layout_regions.results_pane = Some(ratatui::layout::Rect::new(0, 0, 40, 10));
+
+    let original_query = app.input.query().to_string();
+    let mouse = create_mouse_event(5, 2);
+    handle_click(&mut app, Some(Region::ResultsPane), mouse);
+
+    assert_eq!(
+        app.input.query(),
+        original_query,
+        "a single click must only move the cursor — never drill"
+    );
+}
+
+#[test]
+fn test_double_click_autocomplete_accepts_suggestion() {
+    use crate::autocomplete::autocomplete_state::{Suggestion, SuggestionType};
+
+    let mut app = setup_app();
+    app.focus = Focus::InputField;
+    app.input.textarea.insert_str(".");
+    app.autocomplete.update_suggestions(vec![
+        Suggestion::new("name", SuggestionType::Field),
+        Suggestion::new("age", SuggestionType::Field),
+    ]);
+    app.layout_regions.autocomplete = Some(ratatui::layout::Rect::new(0, 0, 30, 6));
+
+    // Row 1 inside the popup border targets the first suggestion ("name").
+    let mouse = create_mouse_event(5, 1);
+    handle_click(&mut app, Some(Region::Autocomplete), mouse);
+    handle_click(&mut app, Some(Region::Autocomplete), mouse);
+
+    assert!(
+        app.input.query().contains("name"),
+        "double-click on a suggestion must insert it into the query, got `{}`",
+        app.input.query()
+    );
+}
+
+#[test]
+fn test_single_click_autocomplete_only_highlights() {
+    use crate::autocomplete::autocomplete_state::{Suggestion, SuggestionType};
+
+    let mut app = setup_app();
+    app.focus = Focus::InputField;
+    app.input.textarea.insert_str(".");
+    let original_query = app.input.query().to_string();
+    app.autocomplete.update_suggestions(vec![
+        Suggestion::new("name", SuggestionType::Field),
+        Suggestion::new("age", SuggestionType::Field),
+    ]);
+    app.layout_regions.autocomplete = Some(ratatui::layout::Rect::new(0, 0, 30, 6));
+
+    // Row 2 inside the popup border targets the second suggestion ("age").
+    let mouse = create_mouse_event(5, 2);
+    handle_click(&mut app, Some(Region::Autocomplete), mouse);
+
+    assert_eq!(
+        app.input.query(),
+        original_query,
+        "single click must not insert anything"
+    );
+    assert_eq!(
+        app.autocomplete.selected_index(),
+        1,
+        "single click must highlight the clicked suggestion"
+    );
+}

--- a/src/app/mouse_hover.rs
+++ b/src/app/mouse_hover.rs
@@ -11,6 +11,7 @@ use crate::layout::Region;
 ///
 /// Updates hover state based on cursor position within components.
 pub fn handle_hover(app: &mut App, region: Option<Region>, mouse: MouseEvent) {
+    app.double_click.reset();
     match region {
         Some(Region::ResultsPane) => hover_results_pane(app, mouse),
         Some(Region::AiWindow) => hover_ai_window(app, mouse),

--- a/src/app/mouse_scroll.rs
+++ b/src/app/mouse_scroll.rs
@@ -18,6 +18,7 @@ pub enum ScrollDirection {
 /// Routes scroll to the component under the cursor.
 /// Falls back to results pane when cursor is outside all regions.
 pub fn handle_scroll(app: &mut App, region: Option<Region>, direction: ScrollDirection) {
+    app.double_click.reset();
     match region {
         Some(Region::ResultsPane) | None => scroll_results(app, direction),
         Some(Region::HelpPopup) => scroll_help(app, direction),

--- a/src/autocomplete/autocomplete_state.rs
+++ b/src/autocomplete/autocomplete_state.rs
@@ -216,6 +216,18 @@ impl AutocompleteState {
         self.selected_index
     }
 
+    /// Highlight a specific suggestion, clamped to the available list.
+    /// Used by mouse interactions where the click target is computed from
+    /// the rendered viewport.
+    pub fn set_selected_index(&mut self, index: usize) {
+        if self.suggestions.is_empty() {
+            return;
+        }
+        let clamped = index.min(self.suggestions.len() - 1);
+        self.selected_index = clamped;
+        self.adjust_scroll_to_selection();
+    }
+
     #[allow(dead_code)]
     pub fn scroll_offset(&self) -> usize {
         self.scroll_offset


### PR DESCRIPTION
## Summary
- Shared `DoubleClickTracker` (`src/app/double_click.rs`) with 400 ms threshold, configurable `Granularity::SameRow`/`SameCell`, region-aware, resets on hover/scroll, doesn't chain into triple-click. Designed to be the single source of truth for any future double-click consumer.
- Results pane: double-click any row → `drill_in(CursorRow)` (same as `>`). Single click still only moves the cursor.
- Autocomplete dropdown: double-click a suggestion → accept it. Closes the long-standing docs gap where the behaviour was advertised but unimplemented.
- Docs updated: `docs/features/mouse.md` adds a "Drill into a row" section; `docs/quick-reference.md` mouse table gains the row-drill row.

## Test plan
- [x] cargo test (3299 unit tests + integration suites pass)
- [x] cargo build --release
- [x] cargo clippy --all-targets --all-features (zero warnings, with -D warnings)
- [x] cargo fmt --all --check
- [x] Manual TUI validation: results-row drill, autocomplete accept, single-click is non-destructive in both panes, hover/scroll/region-change invalidate the pending pair, slow taps (>400 ms) don't pair