### PR TITLE
feat(input): smart source picker with clipboard preview, --paste flag UI

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7,6 +7,7 @@ mod mouse_events;
 mod mouse_hover;
 mod mouse_scroll;
 mod paste_recovery_render;
+mod source_picker_render;
 
 #[cfg(test)]
 mod app_render_tests;

--- a/src/app/app_events.rs
+++ b/src/app/app_events.rs
@@ -15,6 +15,7 @@ use crate::snippets;
 
 mod global;
 pub mod paste_recovery;
+pub mod source_picker;
 
 /// Determine the default help tab based on current app context
 ///
@@ -241,7 +242,9 @@ impl App {
         if event::poll(EVENT_POLL_TIMEOUT)? {
             match event::read()? {
                 Event::Key(key_event) if key_event.kind == KeyEventKind::Press => {
-                    if self.paste_recovery.is_some() {
+                    if self.source_picker.is_some() {
+                        self.handle_source_picker_key_event(key_event);
+                    } else if self.paste_recovery.is_some() {
                         self.handle_paste_recovery_key_event(key_event);
                     } else {
                         self.handle_key_event(key_event);
@@ -249,7 +252,13 @@ impl App {
                     self.mark_dirty();
                 }
                 Event::Paste(text) => {
-                    if self.paste_recovery.is_some() {
+                    if self.source_picker.is_some() {
+                        // Pasting while the picker is open is treated
+                        // as the user explicitly wanting Paste mode.
+                        // Mouse-and-click hookup follows in a later
+                        // step; for now we just drop the bytes — the
+                        // user can press `p`.
+                    } else if self.paste_recovery.is_some() {
                         log::debug!(
                             "paste-recovery: bracketed paste event, {} bytes, {} lines",
                             text.len(),
@@ -265,9 +274,10 @@ impl App {
                     self.mark_dirty();
                 }
                 Event::Mouse(mouse_event) => {
-                    if self.paste_recovery.is_some() {
-                        // Ignore mouse during recovery — there is no
-                        // input/results split to act on.
+                    if self.source_picker.is_some() || self.paste_recovery.is_some() {
+                        // Picker / recovery occupy the screen; no
+                        // input/results split to act on. Mouse hookup
+                        // for the picker follows in a later step.
                     } else {
                         self.handle_mouse_event(mouse_event);
                     }
@@ -277,6 +287,19 @@ impl App {
             }
         }
         Ok(())
+    }
+
+    /// Route a key while the source picker is active. Truly global keys
+    /// (Ctrl+C quit, F1 help) still take precedence; everything else
+    /// goes to the picker handler.
+    fn handle_source_picker_key_event(&mut self, key: KeyEvent) {
+        if handle_truly_global_keys(self, key) {
+            return;
+        }
+        if self.help.visible && handle_help_keys(self, key) {
+            return;
+        }
+        let _ = source_picker::handle_key(self, key);
     }
 
     /// Route a key while paste-recovery is active. Truly global keys

--- a/src/app/app_events/source_picker.rs
+++ b/src/app/app_events/source_picker.rs
@@ -1,0 +1,67 @@
+//! Key routing while the source picker is on screen.
+//!
+//! Bindings:
+//! * `Enter`              — confirm whichever option is highlighted.
+//! * `↑` / `k` / `Left`   — move highlight to previous option.
+//! * `BackTab`            — move highlight to previous option.
+//! * `↓` / `j` / `Right`  — move highlight to next option.
+//! * `Tab`                — move highlight to next option.
+//! * `Esc`                — quit jiq (no JSON has been loaded).
+//!
+//! Anything else is swallowed so a stray key cannot fall through to
+//! the main app handlers, which assume `app.query` is loaded.
+
+use ratatui::crossterm::event::{KeyCode, KeyEvent};
+
+use crate::app::App;
+use crate::input::SourceChoice;
+
+pub fn handle_key(app: &mut App, key: KeyEvent) -> bool {
+    match key.code {
+        KeyCode::Esc => {
+            app.should_quit = true;
+            true
+        }
+        KeyCode::Enter => {
+            // Guard against confirming Clipboard with no usable bytes
+            // — ignore the keystroke so the user must toggle to Paste
+            // first. (Pre-selection already does this; this guard
+            // catches the case where the user toggled to Clipboard
+            // manually.)
+            if can_confirm(app) {
+                app.confirm_source_picker();
+            }
+            true
+        }
+        KeyCode::Up
+        | KeyCode::Left
+        | KeyCode::Char('k')
+        | KeyCode::Char('h')
+        | KeyCode::BackTab => {
+            if let Some(state) = app.source_picker.as_mut() {
+                state.select_previous();
+            }
+            true
+        }
+        KeyCode::Down | KeyCode::Right | KeyCode::Char('j') | KeyCode::Char('l') | KeyCode::Tab => {
+            if let Some(state) = app.source_picker.as_mut() {
+                state.select_next();
+            }
+            true
+        }
+        _ => true,
+    }
+}
+
+/// True when the highlighted option can actually be confirmed:
+/// Clipboard requires the cached bytes to be present, Paste is always
+/// confirmable.
+fn can_confirm(app: &App) -> bool {
+    let Some(state) = app.source_picker.as_ref() else {
+        return false;
+    };
+    match state.selection {
+        SourceChoice::Clipboard => state.clipboard_cache.is_some(),
+        SourceChoice::Paste => true,
+    }
+}

--- a/src/app/app_render.rs
+++ b/src/app/app_render.rs
@@ -11,6 +11,20 @@ impl App {
         self.frame_count = self.frame_count.wrapping_add(1);
         self.layout_regions.clear();
 
+        // Source picker takes the whole screen until the user confirms
+        // a choice; bare TTY launches start here. Help popup still
+        // renders on top so F1 works from the picker.
+        if let Some(picker) = self.source_picker.as_ref() {
+            super::source_picker_render::render(picker, frame, frame.area());
+            if self.help.visible
+                && let Some(help_rect) = crate::help::help_popup_render::render_popup(self, frame)
+            {
+                self.layout_regions.help_popup = Some(help_rect);
+            }
+            render_notification(frame, &mut self.notification);
+            return;
+        }
+
         // Paste-recovery short-circuits the normal layout entirely.
         if self.paste_recovery.is_some() {
             // We render the live `app.input.textarea` here so all

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__paste_recovery_render_tests__snapshot_paste_recovery_after_invalid_paste.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__paste_recovery_render_tests__snapshot_paste_recovery_after_invalid_paste.snap
@@ -1,16 +1,17 @@
 ---
 source: src/app/app_render_tests/paste_recovery_render_tests.rs
+assertion_line: 44
 expression: output
 ---
 "╭ No JSON loaded ──────────────────────────────────────────────────────────────╮"
 "│ Invalid JSON: key must be a string at line 1 column 2                        │"
-"│                                                                              │"
-"│ Paste JSON below and press Enter to load.                                    │"
-"│                                                                              │"
-"│                                                                              │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Paste JSON [INSERT] ─────────────────────────────────────────────────────────╮"
 "│{not json                                                                     │"
+"│                                                                              │"
+"│                                                                              │"
+"│                                                                              │"
+"│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__paste_recovery_render_tests__snapshot_paste_recovery_in_normal_mode_shows_only_insert_toggle.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__paste_recovery_render_tests__snapshot_paste_recovery_in_normal_mode_shows_only_insert_toggle.snap
@@ -1,16 +1,17 @@
 ---
 source: src/app/app_render_tests/paste_recovery_render_tests.rs
+assertion_line: 67
 expression: output
 ---
 "╭ No JSON loaded ──────────────────────────────────────────────────────────────╮"
 "│ No input provided. Clipboard does not contain valid JSON.                    │"
-"│                                                                              │"
-"│ Paste JSON below and press Enter to load.                                    │"
-"│                                                                              │"
-"│                                                                              │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Paste JSON [NORMAL] (press 'i' to edit) ─────────────────────────────────────╮"
 "│{"a":1}                                                                       │"
+"│                                                                              │"
+"│                                                                              │"
+"│                                                                              │"
+"│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__paste_recovery_render_tests__snapshot_paste_recovery_initial.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__paste_recovery_render_tests__snapshot_paste_recovery_initial.snap
@@ -1,16 +1,17 @@
 ---
 source: src/app/app_render_tests/paste_recovery_render_tests.rs
+assertion_line: 31
 expression: output
 ---
 "╭ No JSON loaded ──────────────────────────────────────────────────────────────╮"
 "│ No input provided. Clipboard does not contain valid JSON.                    │"
-"│                                                                              │"
-"│ Paste JSON below and press Enter to load.                                    │"
-"│                                                                              │"
-"│                                                                              │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Paste JSON [INSERT] ─────────────────────────────────────────────────────────╮"
 "│ Paste JSON, then press Enter to load                                         │"
+"│                                                                              │"
+"│                                                                              │"
+"│                                                                              │"
+"│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__paste_recovery_render_tests__snapshot_paste_recovery_with_typed_content.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__paste_recovery_render_tests__snapshot_paste_recovery_with_typed_content.snap
@@ -1,19 +1,20 @@
 ---
 source: src/app/app_render_tests/paste_recovery_render_tests.rs
+assertion_line: 55
 expression: output
 ---
 "╭ No JSON loaded ──────────────────────────────────────────────────────────────╮"
 "│ No input provided. Clipboard does not contain valid JSON.                    │"
-"│                                                                              │"
-"│ Paste JSON below and press Enter to load.                                    │"
-"│                                                                              │"
-"│                                                                              │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Paste JSON [INSERT] ─────────────────────────────────────────────────────────╮"
 "│{                                                                             │"
 "│  "name": "Alice",                                                            │"
 "│  "age": 30                                                                   │"
 "│}                                                                             │"
+"│                                                                              │"
+"│                                                                              │"
+"│                                                                              │"
+"│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"

--- a/src/app/app_state.rs
+++ b/src/app/app_state.rs
@@ -77,8 +77,23 @@ pub struct App {
 }
 
 impl App {
-    /// Create App with deferred file loading
+    /// Create App with deferred file loading.
     pub fn new_with_loader(loader: FileLoader, config: &Config) -> Self {
+        Self::new_with_pre_input(Some(loader), None, config)
+    }
+
+    /// Create App that drops directly into the manual paste-recovery
+    /// flow, without first reading the clipboard. Used by `--paste` and
+    /// the source picker's Paste option.
+    pub fn new_with_paste_recovery(state: PasteRecoveryState, config: &Config) -> Self {
+        Self::new_with_pre_input(None, Some(state), config)
+    }
+
+    fn new_with_pre_input(
+        loader: Option<FileLoader>,
+        paste_recovery: Option<PasteRecoveryState>,
+        config: &Config,
+    ) -> Self {
         let anthropic_configured =
             config.ai.anthropic.api_key.is_some() && config.ai.anthropic.model.is_some();
         let bedrock_configured =
@@ -150,8 +165,8 @@ impl App {
         Self {
             input: InputState::new(),
             query: None,
-            file_loader: Some(loader),
-            paste_recovery: None,
+            file_loader: loader,
+            paste_recovery,
             focus: Focus::InputField,
             results_scroll: ScrollState::new(),
             results_cursor: CursorState::new(),

--- a/src/app/app_state.rs
+++ b/src/app/app_state.rs
@@ -4,7 +4,7 @@ use crate::config::{ClipboardBackend, Config};
 use crate::help::HelpPopupState;
 use crate::history::HistoryState;
 use crate::input::loader::LoaderSource;
-use crate::input::{FileLoader, InputState, PasteRecoveryState};
+use crate::input::{FileLoader, InputState, PasteRecoveryState, SourcePickerState};
 use crate::layout::LayoutRegions;
 use crate::notification::NotificationState;
 use crate::path_at_cursor::PathAtCursorCache;
@@ -34,6 +34,7 @@ pub struct App {
     pub query: Option<QueryState>,
     pub file_loader: Option<FileLoader>,
     pub paste_recovery: Option<PasteRecoveryState>,
+    pub source_picker: Option<SourcePickerState>,
     pub focus: Focus,
     pub results_scroll: ScrollState,
     pub results_cursor: CursorState,
@@ -79,19 +80,29 @@ pub struct App {
 impl App {
     /// Create App with deferred file loading.
     pub fn new_with_loader(loader: FileLoader, config: &Config) -> Self {
-        Self::new_with_pre_input(Some(loader), None, config)
+        Self::new_with_pre_input(Some(loader), None, None, config)
     }
 
     /// Create App that drops directly into the manual paste-recovery
     /// flow, without first reading the clipboard. Used by `--paste` and
     /// the source picker's Paste option.
     pub fn new_with_paste_recovery(state: PasteRecoveryState, config: &Config) -> Self {
-        Self::new_with_pre_input(None, Some(state), config)
+        Self::new_with_pre_input(None, Some(state), None, config)
+    }
+
+    /// Create App that opens with the source picker visible. Used on
+    /// bare TTY launches (no file argument, no piped stdin, no
+    /// `--clipboard` / `--paste`). The picker holds its own
+    /// launch-time clipboard snapshot so the post-confirm load doesn't
+    /// re-read the clipboard.
+    pub fn new_with_source_picker(state: SourcePickerState, config: &Config) -> Self {
+        Self::new_with_pre_input(None, None, Some(state), config)
     }
 
     fn new_with_pre_input(
         loader: Option<FileLoader>,
         paste_recovery: Option<PasteRecoveryState>,
+        source_picker: Option<SourcePickerState>,
         config: &Config,
     ) -> Self {
         let anthropic_configured =
@@ -166,6 +177,7 @@ impl App {
             input: InputState::new(),
             query: None,
             file_loader: loader,
+            source_picker,
             paste_recovery,
             focus: Focus::InputField,
             results_scroll: ScrollState::new(),
@@ -201,6 +213,37 @@ impl App {
             double_click: super::double_click::DoubleClickTracker::new(),
             back_button_hovered: false,
         }
+    }
+
+    /// Commit the source picker's currently-highlighted choice and
+    /// transition the app into the matching pre-input state. Called on
+    /// Enter / mouse click / `c` / `p`.
+    ///
+    /// Clipboard branch reuses the cached bytes from the launch peek,
+    /// so the system clipboard is never re-read. Paste branch enters
+    /// the explicit-paste editor (cyan border, neutral title).
+    pub fn confirm_source_picker(&mut self) {
+        let Some(picker) = self.source_picker.take() else {
+            return;
+        };
+        match picker.selection {
+            crate::input::SourceChoice::Clipboard => {
+                if let Some(bytes) = picker.clipboard_cache {
+                    self.file_loader = Some(FileLoader::from_clipboard_string(bytes));
+                } else {
+                    // Picker only allows confirming Clipboard when the
+                    // cache is non-empty (peek was Usable). If we ever
+                    // arrive here, fall back to a fresh read so the
+                    // user isn't left in a stuck state.
+                    log::warn!("confirm_source_picker: Clipboard chosen with no cache; re-reading");
+                    self.file_loader = Some(FileLoader::load_clipboard_blocking());
+                }
+            }
+            crate::input::SourceChoice::Paste => {
+                self.paste_recovery = Some(PasteRecoveryState::new_explicit());
+            }
+        }
+        self.mark_dirty();
     }
 
     /// Poll file loader and initialize QueryState when complete

--- a/src/app/paste_recovery_render.rs
+++ b/src/app/paste_recovery_render.rs
@@ -7,6 +7,7 @@ use tui_textarea::TextArea;
 
 use crate::editor::EditorMode;
 use crate::input::PasteRecoveryState;
+use crate::input::paste_recovery::PasteRecoveryMode;
 use crate::theme;
 
 /// Render the paste-recovery view as a full replacement for the normal
@@ -32,26 +33,49 @@ pub fn render(
 }
 
 fn render_error_block(state: &PasteRecoveryState, frame: &mut Frame, area: Rect) {
+    // Recovery mode (clipboard failure): red border, "No JSON loaded"
+    // title, message styled as an error.
+    // Explicit mode (--paste / picker→Paste): cyan border, neutral
+    // "Paste JSON" title, message styled as plain instructions.
+    let (title, border_color, message_color, show_secondary_hint) = match state.mode {
+        PasteRecoveryMode::Recovery => (
+            " No JSON loaded ",
+            theme::input::BORDER_ERROR,
+            theme::input::BORDER_ERROR,
+            true,
+        ),
+        PasteRecoveryMode::Explicit => (
+            " Paste JSON ",
+            theme::input::MODE_INSERT,
+            theme::palette::TEXT,
+            false,
+        ),
+    };
+
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .title(" No JSON loaded ")
-        .border_style(Style::default().fg(theme::input::BORDER_ERROR))
+        .title(title)
+        .border_style(Style::default().fg(border_color))
         .padding(Padding::horizontal(1));
 
-    let lines: Vec<Line<'_>> = vec![
-        Line::from(Span::styled(
-            state.error_message.clone(),
-            Style::default()
-                .fg(theme::input::BORDER_ERROR)
-                .add_modifier(Modifier::BOLD),
-        )),
-        Line::raw(""),
-        Line::from(Span::styled(
+    let mut lines: Vec<Line<'_>> = vec![Line::from(Span::styled(
+        state.error_message.clone(),
+        Style::default()
+            .fg(message_color)
+            .add_modifier(Modifier::BOLD),
+    ))];
+    // Recovery mode echoes the failure diagnosis on the first line and
+    // needs a secondary hint telling the user what to do next. Explicit
+    // mode's first-line message ("Paste JSON below and press Enter to
+    // load.") is already that hint; a second copy is just clutter.
+    if show_secondary_hint {
+        lines.push(Line::raw(""));
+        lines.push(Line::from(Span::styled(
             "Paste JSON below and press Enter to load.",
             Style::default().fg(theme::palette::TEXT),
-        )),
-    ];
+        )));
+    }
 
     let paragraph = Paragraph::new(lines)
         .block(block)

--- a/src/app/paste_recovery_render.rs
+++ b/src/app/paste_recovery_render.rs
@@ -24,32 +24,55 @@ pub fn render(
     frame: &mut Frame,
     area: Rect,
 ) -> Rect {
-    let layout = Layout::vertical([Constraint::Length(7), Constraint::Min(3)]).split(area);
+    // Top block height is data-driven, sized to the message body plus
+    // two border rows. Returns 0 when there's nothing to say (plain
+    // explicit-paste invocation), in which case the textarea claims
+    // the full screen — its title and placeholder already communicate
+    // what to do, so an empty info box would just be visual noise.
+    let top_height = top_block_height(state);
+    if top_height == 0 {
+        render_textarea(textarea, editor_mode, frame, area);
+        return area;
+    }
+    let layout = Layout::vertical([Constraint::Length(top_height), Constraint::Min(3)]).split(area);
 
-    render_error_block(state, frame, layout[0]);
+    render_top_block(state, frame, layout[0]);
     render_textarea(textarea, editor_mode, frame, layout[1]);
 
     area
 }
 
-fn render_error_block(state: &PasteRecoveryState, frame: &mut Frame, area: Rect) {
+/// Pick a height for the top info / error block based on how many
+/// content rows it'll actually render. Returns 0 when the block
+/// should be suppressed entirely (Explicit mode with no context line).
+fn top_block_height(state: &PasteRecoveryState) -> u16 {
+    if state.error_message.is_empty() {
+        return 0;
+    }
+    // Two border rows + the joined message lines. Capped so a
+    // pathological multi-line message can't push the textarea
+    // off-screen.
+    let body_lines = state.error_message.split('\n').count() as u16;
+    (body_lines + 2).clamp(3, 8)
+}
+
+fn render_top_block(state: &PasteRecoveryState, frame: &mut Frame, area: Rect) {
     // Recovery mode (clipboard failure): red border, "No JSON loaded"
     // title, message styled as an error.
-    // Explicit mode (--paste / picker→Paste): cyan border, neutral
-    // "Paste JSON" title, message styled as plain instructions.
-    let (title, border_color, message_color, show_secondary_hint) = match state.mode {
+    // Explicit mode (--paste / picker→Paste fallback with context):
+    // cyan border, neutral "Info" title — the box below this one is
+    // titled "Paste JSON", so we deliberately avoid the same title
+    // here. The textarea's own title and placeholder already tell the
+    // user "paste JSON, press Enter to load", so the info box never
+    // needs to repeat that instruction; it carries only the
+    // diagnosis / context that's NEW to this screen.
+    let (title, border_color, message_color) = match state.mode {
         PasteRecoveryMode::Recovery => (
             " No JSON loaded ",
             theme::input::BORDER_ERROR,
             theme::input::BORDER_ERROR,
-            true,
         ),
-        PasteRecoveryMode::Explicit => (
-            " Paste JSON ",
-            theme::input::MODE_INSERT,
-            theme::palette::TEXT,
-            false,
-        ),
+        PasteRecoveryMode::Explicit => (" Info ", theme::input::MODE_INSERT, theme::palette::TEXT),
     };
 
     let block = Block::default()
@@ -59,23 +82,21 @@ fn render_error_block(state: &PasteRecoveryState, frame: &mut Frame, area: Rect)
         .border_style(Style::default().fg(border_color))
         .padding(Padding::horizontal(1));
 
-    let mut lines: Vec<Line<'_>> = vec![Line::from(Span::styled(
-        state.error_message.clone(),
-        Style::default()
-            .fg(message_color)
-            .add_modifier(Modifier::BOLD),
-    ))];
-    // Recovery mode echoes the failure diagnosis on the first line and
-    // needs a secondary hint telling the user what to do next. Explicit
-    // mode's first-line message ("Paste JSON below and press Enter to
-    // load.") is already that hint; a second copy is just clutter.
-    if show_secondary_hint {
-        lines.push(Line::raw(""));
-        lines.push(Line::from(Span::styled(
-            "Paste JSON below and press Enter to load.",
-            Style::default().fg(theme::palette::TEXT),
-        )));
-    }
+    // Split on '\n' so callers can pack multiple lines into
+    // `error_message` if needed (a parse error spanning multiple lines,
+    // for instance). Each line gets the same styling.
+    let lines: Vec<Line<'_>> = state
+        .error_message
+        .split('\n')
+        .map(|line| {
+            Line::from(Span::styled(
+                line.to_string(),
+                Style::default()
+                    .fg(message_color)
+                    .add_modifier(Modifier::BOLD),
+            ))
+        })
+        .collect();
 
     let paragraph = Paragraph::new(lines)
         .block(block)

--- a/src/app/source_picker_render.rs
+++ b/src/app/source_picker_render.rs
@@ -1,0 +1,225 @@
+//! Source-picker view.
+//!
+//! Two regions stacked vertically:
+//!
+//! 1. **Option banner** at the top — fixed-height box listing Clipboard
+//!    and Paste. The bottom border carries the keyboard-hint strip,
+//!    whose Enter label adapts to the highlighted option (`Load` for
+//!    Clipboard, `Open paste editor` for Paste).
+//! 2. **Preview** below — fills the rest of the viewport. When
+//!    Clipboard is highlighted the cached payload's first lines render
+//!    inside a bordered box. When Paste is highlighted the area is
+//!    deliberately left empty: the user already knows what Enter will
+//!    do from the hint strip, so a "Paste" placeholder box would just
+//!    add visual noise.
+
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Padding, Paragraph, Wrap};
+
+use crate::input::loader::ClipboardPeek;
+use crate::input::{SourceChoice, SourcePickerState};
+use crate::theme;
+
+/// Hard cap on bytes scanned when building the preview head. The
+/// cached payload may be megabytes; scanning ~4 KB is enough to show
+/// the JSON shape without copying the whole buffer for every render.
+const PREVIEW_MAX_BYTES: usize = 4 * 1024;
+
+/// Render the picker view (option banner + optional preview pane) and
+/// return the area it consumed.
+pub fn render(state: &SourcePickerState, frame: &mut Frame, area: Rect) -> Rect {
+    if area.height < 6 || area.width < 40 {
+        render_too_small(frame, area);
+        return area;
+    }
+
+    // Option banner is fixed-height: 2 borders + 2 option rows = 4
+    // rows. The hint strip rides the banner's bottom border so it stays
+    // visible regardless of which option is highlighted.
+    const BANNER_HEIGHT: u16 = 4;
+    let chunks =
+        Layout::vertical([Constraint::Length(BANNER_HEIGHT), Constraint::Min(0)]).split(area);
+    let banner_area = chunks[0];
+    let preview_area = chunks[1];
+
+    render_banner(state, frame, banner_area);
+    if matches!(state.selection, SourceChoice::Clipboard) {
+        render_preview(state, frame, preview_area);
+    }
+
+    area
+}
+
+fn render_banner(state: &SourcePickerState, frame: &mut Frame, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .title(" Choose JSON input source ")
+        .border_style(Style::default().fg(theme::input::MODE_INSERT))
+        .padding(Padding::horizontal(1))
+        .title_bottom(bottom_hints(state.selection).alignment(Alignment::Center));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let lines: Vec<Line<'static>> = vec![
+        option_line(state, SourceChoice::Clipboard),
+        option_line(state, SourceChoice::Paste),
+    ];
+    let paragraph = Paragraph::new(lines).wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, inner);
+}
+
+fn render_preview(state: &SourcePickerState, frame: &mut Frame, area: Rect) {
+    // Only Usable peeks reach this branch — main.rs gates the picker
+    // off entirely when the clipboard isn't usable, so the preview
+    // pane never has to handle "no JSON" itself.
+    let bytes = match &state.peek {
+        ClipboardPeek::Usable(bytes) => bytes.as_str(),
+        _ => return,
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .title(" Clipboard preview ")
+        .border_style(Style::default().fg(theme::input::BORDER_UNFOCUSED))
+        .padding(Padding::horizontal(1));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // Use whatever vertical room the preview pane has; the cached
+    // payload may be many lines, but we never need more than the inner
+    // height to fill the screen.
+    let max_lines = inner.height.saturating_sub(1) as usize; // reserve 1 row for tail
+    let lines = clipboard_preview_lines(bytes, max_lines.max(1));
+    let paragraph = Paragraph::new(lines).wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, inner);
+}
+
+/// Build the lines shown in the preview pane. Splits on newlines,
+/// keeps at most `max_lines` of head content, and appends a "… (N
+/// more lines, M.M KB more)" tail when content is elided.
+fn clipboard_preview_lines(bytes: &str, max_lines: usize) -> Vec<Line<'static>> {
+    let total_lines = bytes.lines().count();
+    let total_bytes = bytes.len();
+
+    // Cap the byte slice we scan so render time stays O(viewport)
+    // even on a 50 MB clipboard.
+    let head = if bytes.len() <= PREVIEW_MAX_BYTES {
+        bytes
+    } else {
+        let mut end = PREVIEW_MAX_BYTES;
+        while end > 0 && !bytes.is_char_boundary(end) {
+            end -= 1;
+        }
+        &bytes[..end]
+    };
+
+    let visible: Vec<&str> = head.lines().take(max_lines).collect();
+    let visible_byte_count: usize = visible.iter().map(|l| l.len() + 1).sum();
+    let truncated = visible.len() < total_lines || visible_byte_count < total_bytes;
+
+    let mut out: Vec<Line<'static>> = visible
+        .iter()
+        .map(|line| {
+            Line::from(Span::styled(
+                line.to_string(),
+                Style::default().fg(theme::palette::TEXT),
+            ))
+        })
+        .collect();
+
+    if truncated {
+        let elided_lines = total_lines.saturating_sub(visible.len());
+        let elided_bytes = total_bytes.saturating_sub(visible_byte_count);
+        let tail = match (elided_lines, elided_bytes) {
+            (0, b) if b > 0 => format!("… ({} more)", fmt_bytes(b)),
+            (l, 0) => format!("… ({l} more line{})", if l == 1 { "" } else { "s" }),
+            (l, b) => format!(
+                "… ({} more line{}, {} more)",
+                l,
+                if l == 1 { "" } else { "s" },
+                fmt_bytes(b)
+            ),
+        };
+        out.push(Line::from(Span::styled(
+            tail,
+            Style::default()
+                .fg(theme::palette::TEXT_MUTED)
+                .add_modifier(Modifier::ITALIC),
+        )));
+    }
+    out
+}
+
+/// Smaller-than-min terminal: replace the picker with a single-line
+/// hint pointing at the explicit flags so the user has an escape hatch
+/// without resizing.
+fn render_too_small(frame: &mut Frame, area: Rect) {
+    let p = Paragraph::new(vec![
+        Line::from(Span::styled(
+            "Terminal too small for the source picker.",
+            Style::default()
+                .fg(theme::input::BORDER_ERROR)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::raw(""),
+        Line::from(Span::styled(
+            "Resize, or relaunch with --clipboard / --paste.",
+            Style::default().fg(theme::palette::TEXT),
+        )),
+    ])
+    .wrap(Wrap { trim: false });
+    frame.render_widget(p, area);
+}
+
+fn option_line(state: &SourcePickerState, choice: SourceChoice) -> Line<'static> {
+    let selected = state.selection == choice;
+    let marker = if selected { "▶" } else { " " };
+    let label = match choice {
+        SourceChoice::Clipboard => "Clipboard",
+        SourceChoice::Paste => "Paste",
+    };
+    let style = if selected {
+        Style::default()
+            .fg(theme::input::MODE_INSERT)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme::palette::TEXT)
+    };
+    Line::from(vec![
+        Span::styled(format!(" {} ", marker), style),
+        Span::styled(label.to_string(), style),
+    ])
+}
+
+/// Build the keyboard-hint strip rendered on the option banner's
+/// bottom border. The Enter label is contextual: it tells the user
+/// what's about to happen if they confirm the current selection.
+fn bottom_hints(selection: SourceChoice) -> Line<'static> {
+    let enter_label = match selection {
+        SourceChoice::Clipboard => "Load",
+        SourceChoice::Paste => "Open paste editor",
+    };
+    let entries: [(&'static str, &'static str); 3] =
+        [("Enter", enter_label), ("↑/↓", "Switch"), ("Esc", "Quit")];
+    theme::border_hints::build_hints(&entries, theme::input::MODE_INSERT)
+}
+
+/// Format a byte count using SI-style suffixes (B / KB / MB).
+fn fmt_bytes(n: usize) -> String {
+    const KB: usize = 1024;
+    const MB: usize = 1024 * 1024;
+    if n >= MB {
+        format!("{:.1} MB", n as f64 / MB as f64)
+    } else if n >= KB {
+        format!("{:.1} KB", n as f64 / KB as f64)
+    } else {
+        format!("{} B", n)
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -2,10 +2,12 @@ pub mod input_render;
 mod input_state;
 pub mod loader;
 pub mod paste_recovery;
+pub mod source_picker;
 
 pub use input_state::InputState;
 pub use loader::FileLoader;
 pub use paste_recovery::PasteRecoveryState;
+pub use source_picker::{SourceChoice, SourcePickerState};
 
 #[cfg(test)]
 mod input_render_tests;

--- a/src/input/loader.rs
+++ b/src/input/loader.rs
@@ -144,21 +144,50 @@ impl FileLoader {
     }
 }
 
-/// Validate that content is valid JSON or JSONL
-///
-/// Uses StreamDeserializer to handle both single JSON values and JSONL (multiple values).
-pub(crate) fn validate_json_or_jsonl(content: &str) -> Result<(), JiqError> {
+/// Outcome of a single-pass scan over `content`. Reports both validity
+/// and whether every top-level value is an object or array.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct JsonScan {
+    pub count: usize,
+    pub all_containers: bool,
+}
+
+/// Walk every top-level JSON value in `content` once, reporting count
+/// and whether every value is an object or array. Single-pass
+/// replacement for the old "validate then re-walk to check container
+/// shape" pattern; cheaper on large clipboard inputs and rules out
+/// the "scan disagreed with itself across two passes" failure mode.
+pub(crate) fn scan_json_or_jsonl(content: &str) -> Result<JsonScan, JiqError> {
     let deserializer = serde_json::Deserializer::from_str(content).into_iter::<serde_json::Value>();
     let mut count = 0;
+    let mut all_containers = true;
     for result in deserializer {
-        result.map_err(|e| JiqError::InvalidJson(e.to_string()))?;
+        let value = result.map_err(|e| JiqError::InvalidJson(e.to_string()))?;
+        if !value.is_object() && !value.is_array() {
+            all_containers = false;
+        }
         count += 1;
     }
     if count == 0 {
         return Err(JiqError::InvalidJson("Empty input".to_string()));
     }
-    log::debug!("JSON validation: {} top-level value(s)", count);
-    Ok(())
+    log::debug!(
+        "JSON validation: {} top-level value(s), all_containers={}",
+        count,
+        all_containers
+    );
+    Ok(JsonScan {
+        count,
+        all_containers,
+    })
+}
+
+/// Validate that content is valid JSON or JSONL.
+///
+/// Thin wrapper over [`scan_json_or_jsonl`] for callers that only care
+/// about parse validity (file/stdin loaders, paste-recovery accept).
+pub(crate) fn validate_json_or_jsonl(content: &str) -> Result<(), JiqError> {
+    scan_json_or_jsonl(content).map(|_| ())
 }
 
 /// Synchronous file loading (runs in background thread)
@@ -231,9 +260,17 @@ fn load_clipboard_sync() -> Result<String, JiqError> {
         return Err(input_load_error(InputErrorReason::ClipboardEmpty));
     }
 
-    if validate_json_or_jsonl(&contents).is_err() {
-        log::debug!("Clipboard contents are not valid JSON or JSONL");
-        return Err(input_load_error(InputErrorReason::ClipboardInvalidJson));
+    let scan = match scan_json_or_jsonl(&contents) {
+        Ok(s) => s,
+        Err(_) => {
+            log::debug!("Clipboard contents are not valid JSON or JSONL");
+            return Err(input_load_error(InputErrorReason::ClipboardInvalidJson));
+        }
+    };
+
+    if !scan.all_containers {
+        log::debug!("Clipboard contains a JSON primitive, not an object or array");
+        return Err(input_load_error(InputErrorReason::ClipboardPrimitive));
     }
 
     Ok(contents)
@@ -270,6 +307,11 @@ pub(crate) enum InputErrorReason {
     ClipboardEmpty,
     /// Clipboard had non-empty content but it didn't parse as JSON/JSONL.
     ClipboardInvalidJson,
+    /// Clipboard parsed as valid JSON but the top-level value is a
+    /// primitive (number, string, bool, null) rather than an object or
+    /// array. Useful jq queries operate on objects or arrays, so we
+    /// reject primitives and route the user to the manual-paste flow.
+    ClipboardPrimitive,
     /// Piped stdin was actually a terminal (no real data to read).
     NoStdin,
 }
@@ -286,6 +328,9 @@ fn format_input_load_error(reason: InputErrorReason) -> String {
         InputErrorReason::ClipboardEmpty => "No input provided. Clipboard is empty.",
         InputErrorReason::ClipboardInvalidJson => {
             "No input provided. Clipboard does not contain valid JSON."
+        }
+        InputErrorReason::ClipboardPrimitive => {
+            "Clipboard contained a non-JSON value (object or array required)."
         }
         InputErrorReason::NoStdin => "No input provided.",
     };

--- a/src/input/loader.rs
+++ b/src/input/loader.rs
@@ -104,6 +104,22 @@ impl FileLoader {
         }
     }
 
+    /// Wrap an already-validated clipboard payload in a `FileLoader`
+    /// without re-reading the system clipboard. Used by the source
+    /// picker after the user confirms the Clipboard option: the bytes
+    /// were peeked at launch and validated by the smart-default check,
+    /// so a second read would be wasted work (and on remote SSH a
+    /// second OSC 52 round-trip).
+    pub fn from_clipboard_string(json: String) -> Self {
+        let (tx, rx) = channel();
+        let _ = tx.send(Ok(json.clone()));
+        Self {
+            state: LoadingState::Complete(json),
+            rx: Some(rx),
+            source: LoaderSource::Clipboard,
+        }
+    }
+
     /// Poll for loading completion (non-blocking)
     ///
     /// Checks the channel for results without blocking. Returns None if still loading,
@@ -147,7 +163,7 @@ impl FileLoader {
 /// Outcome of a single-pass scan over `content`. Reports both validity
 /// and whether every top-level value is an object or array.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct JsonScan {
+pub struct JsonScan {
     pub count: usize,
     pub all_containers: bool,
 }
@@ -276,6 +292,90 @@ fn load_clipboard_sync() -> Result<String, JiqError> {
     Ok(contents)
 }
 
+/// Outcome of a non-committing clipboard peek. The source picker uses
+/// this to decide which option to pre-select and what context to show
+/// the user, *without* committing to a load — the user still confirms
+/// with Enter / a click.
+///
+/// The `Ok` payload carries the raw clipboard bytes so the picker can
+/// hand them straight to [`FileLoader::from_clipboard_string`] on
+/// confirm; we deliberately avoid a second clipboard read because OSC
+/// 52 over SSH can take ~1s.
+#[derive(Debug, Clone)]
+pub enum ClipboardPeek {
+    /// Clipboard read succeeded and parsed as one or more objects /
+    /// arrays. Contains the raw bytes; the picker hands these straight
+    /// to [`FileLoader::from_clipboard_string`] on confirm.
+    Usable(String),
+    /// Clipboard read succeeded but contents aren't queryable JSON.
+    Empty,
+    Invalid,
+    Primitive,
+    /// Clipboard read failed entirely (arboard + OSC 52 both errored).
+    Unreadable,
+}
+
+impl ClipboardPeek {
+    /// Whether the clipboard contents are actually queryable. Drives
+    /// whether the source picker is shown at all: if the answer is
+    /// false, the picker has only one operable option (Paste) and we
+    /// skip it entirely in favour of dropping straight into the
+    /// explicit-paste editor.
+    pub fn is_usable(&self) -> bool {
+        matches!(self, ClipboardPeek::Usable(_))
+    }
+
+    /// Single-line context shown to the user when the picker has Paste
+    /// pre-selected because the clipboard was unusable. Returns `None`
+    /// for `Usable` (no failure to explain). Each message describes
+    /// only what jiq saw — the editor's title and placeholder already
+    /// tell the user how to proceed.
+    pub fn failure_context(&self) -> Option<&'static str> {
+        match self {
+            ClipboardPeek::Usable(_) => None,
+            ClipboardPeek::Unreadable => Some("Couldn't read the clipboard"),
+            ClipboardPeek::Empty => Some("Clipboard is empty"),
+            ClipboardPeek::Invalid => Some("Clipboard contents aren't valid JSON"),
+            ClipboardPeek::Primitive => Some(
+                "Clipboard JSON is a primitive (e.g. 42, \"x\", true) — needs an object or array",
+            ),
+        }
+    }
+}
+
+/// Read the system clipboard and classify its contents without
+/// committing to a load. Mirrors the validation gate of
+/// [`load_clipboard_sync`] but never returns a `JiqError`; instead the
+/// outcome is encoded as a [`ClipboardPeek`] so the picker can decide
+/// which option to pre-select and what to show in the preview pane.
+///
+/// Runs on the main thread before TUI init, just like
+/// [`FileLoader::load_clipboard_blocking`] — same OSC 52 raw-mode
+/// caveat applies.
+pub fn peek_clipboard() -> ClipboardPeek {
+    log::debug!("Peeking clipboard for picker");
+    let contents = match read_clipboard_text() {
+        Ok(text) => text,
+        Err(reason) => {
+            log::debug!("Clipboard unavailable: {}", reason);
+            return ClipboardPeek::Unreadable;
+        }
+    };
+    log::debug!("Clipboard peek: {} bytes", contents.len());
+
+    if contents.trim().is_empty() {
+        return ClipboardPeek::Empty;
+    }
+    let scan = match scan_json_or_jsonl(&contents) {
+        Ok(s) => s,
+        Err(_) => return ClipboardPeek::Invalid,
+    };
+    if !scan.all_containers {
+        return ClipboardPeek::Primitive;
+    }
+    ClipboardPeek::Usable(contents)
+}
+
 /// Try the system clipboard via `arboard`, then OSC 52 if that fails.
 fn read_clipboard_text() -> Result<String, String> {
     match arboard::Clipboard::new().and_then(|mut c| c.get_text()) {
@@ -322,15 +422,11 @@ pub(crate) fn input_load_error(reason: InputErrorReason) -> JiqError {
 
 fn format_input_load_error(reason: InputErrorReason) -> String {
     let detail = match reason {
-        InputErrorReason::ClipboardUnreadable => {
-            "No input provided. Could not read the system clipboard."
-        }
-        InputErrorReason::ClipboardEmpty => "No input provided. Clipboard is empty.",
-        InputErrorReason::ClipboardInvalidJson => {
-            "No input provided. Clipboard does not contain valid JSON."
-        }
+        InputErrorReason::ClipboardUnreadable => "Couldn't read the clipboard.",
+        InputErrorReason::ClipboardEmpty => "Clipboard is empty.",
+        InputErrorReason::ClipboardInvalidJson => "Clipboard contents aren't valid JSON.",
         InputErrorReason::ClipboardPrimitive => {
-            "Clipboard contained a non-JSON value (object or array required)."
+            "Clipboard JSON is a primitive (e.g. 42, \"x\", true) — needs an object or array."
         }
         InputErrorReason::NoStdin => "No input provided.",
     };

--- a/src/input/loader_tests.rs
+++ b/src/input/loader_tests.rs
@@ -203,12 +203,12 @@ fn test_input_load_error_clipboard_unreadable_message_shape() {
     let err = input_load_error(InputErrorReason::ClipboardUnreadable);
     match err {
         JiqError::Io(msg) => {
-            assert!(msg.contains("No input provided"));
-            assert!(msg.contains("Could not read the system clipboard"));
+            assert!(msg.contains("Couldn't read the clipboard"));
             assert!(msg.contains("Usage:"));
             assert!(msg.contains("jiq <file>"));
             assert!(msg.contains("cat data.json | jiq"));
             assert!(msg.contains("# load from system clipboard"));
+            // Internal implementation details must not leak to users.
             assert!(!msg.to_lowercase().contains("x11"));
             assert!(!msg.to_lowercase().contains("arboard"));
         }
@@ -227,7 +227,7 @@ fn test_input_load_error_clipboard_empty_distinguished_from_unreadable() {
         _ => panic!("expected Io"),
     };
 
-    assert!(unreadable.contains("Could not read"));
+    assert!(unreadable.contains("Couldn't read the clipboard"));
     assert!(empty.contains("Clipboard is empty"));
     assert_ne!(unreadable, empty);
 }
@@ -243,8 +243,8 @@ fn test_input_load_error_invalid_json_distinguishes_from_unreadable() {
         _ => panic!("expected Io"),
     };
 
-    assert!(invalid.contains("does not contain valid JSON"));
-    assert!(!unreadable.contains("does not contain valid JSON"));
+    assert!(invalid.contains("aren't valid JSON"));
+    assert!(!unreadable.contains("aren't valid JSON"));
 
     // All clipboard-failure variants share the three-line usage block so
     // users always see all valid invocation forms regardless of how they
@@ -368,10 +368,8 @@ fn test_input_load_error_clipboard_primitive_message() {
     let err = input_load_error(InputErrorReason::ClipboardPrimitive);
     match err {
         JiqError::Io(msg) => {
-            assert!(msg.contains("non-JSON value"));
+            assert!(msg.contains("primitive"));
             assert!(msg.contains("object or array"));
-            // No literal echo of the clipboard contents (privacy).
-            assert!(!msg.contains("`42`"));
         }
         other => panic!("expected JiqError::Io, got {:?}", other),
     }

--- a/src/input/loader_tests.rs
+++ b/src/input/loader_tests.rs
@@ -276,7 +276,8 @@ fn test_validate_json_or_jsonl_rejects_plain_text() {
 }
 
 // ============================================================================
-// scan_json_or_jsonl Tests (Phase 1 — M4 single-pass scan)
+// Single-pass `scan_json_or_jsonl` — reports both validity and whether every
+// top-level value is an object or array, in one pass.
 // ============================================================================
 
 #[test]

--- a/src/input/loader_tests.rs
+++ b/src/input/loader_tests.rs
@@ -276,6 +276,107 @@ fn test_validate_json_or_jsonl_rejects_plain_text() {
 }
 
 // ============================================================================
+// scan_json_or_jsonl Tests (Phase 1 — M4 single-pass scan)
+// ============================================================================
+
+#[test]
+fn test_scan_object_is_container() {
+    let scan = scan_json_or_jsonl(r#"{"a": 1}"#).unwrap();
+    assert_eq!(scan.count, 1);
+    assert!(scan.all_containers);
+}
+
+#[test]
+fn test_scan_array_is_container() {
+    let scan = scan_json_or_jsonl(r#"[1, 2, 3]"#).unwrap();
+    assert_eq!(scan.count, 1);
+    assert!(scan.all_containers);
+}
+
+#[test]
+fn test_scan_bare_number_is_primitive() {
+    let scan = scan_json_or_jsonl("42").unwrap();
+    assert_eq!(scan.count, 1);
+    assert!(!scan.all_containers);
+}
+
+#[test]
+fn test_scan_bare_string_is_primitive() {
+    let scan = scan_json_or_jsonl(r#""hello""#).unwrap();
+    assert_eq!(scan.count, 1);
+    assert!(!scan.all_containers);
+}
+
+#[test]
+fn test_scan_bare_bool_is_primitive() {
+    let scan = scan_json_or_jsonl("true").unwrap();
+    assert_eq!(scan.count, 1);
+    assert!(!scan.all_containers);
+}
+
+#[test]
+fn test_scan_bare_null_is_primitive() {
+    let scan = scan_json_or_jsonl("null").unwrap();
+    assert_eq!(scan.count, 1);
+    assert!(!scan.all_containers);
+}
+
+#[test]
+fn test_scan_jsonl_all_containers() {
+    let jsonl = "{\"a\": 1}\n{\"b\": 2}\n[3, 4]";
+    let scan = scan_json_or_jsonl(jsonl).unwrap();
+    assert_eq!(scan.count, 3);
+    assert!(scan.all_containers);
+}
+
+#[test]
+fn test_scan_jsonl_with_one_primitive_rejects_all_containers() {
+    let jsonl = "{\"a\": 1}\n42\n{\"b\": 2}";
+    let scan = scan_json_or_jsonl(jsonl).unwrap();
+    assert_eq!(scan.count, 3);
+    assert!(
+        !scan.all_containers,
+        "JSONL with any primitive should set all_containers=false"
+    );
+}
+
+#[test]
+fn test_scan_parse_error_returns_err() {
+    let result = scan_json_or_jsonl(r#"{"a": invalid}"#);
+    assert!(matches!(result, Err(JiqError::InvalidJson(_))));
+}
+
+#[test]
+fn test_scan_empty_returns_err() {
+    let result = scan_json_or_jsonl("");
+    assert!(matches!(result, Err(JiqError::InvalidJson(_))));
+}
+
+#[test]
+fn test_scan_whitespace_only_returns_err() {
+    let result = scan_json_or_jsonl("  \n\t  ");
+    assert!(matches!(result, Err(JiqError::InvalidJson(_))));
+}
+
+// ============================================================================
+// ClipboardPrimitive error variant
+// ============================================================================
+
+#[test]
+fn test_input_load_error_clipboard_primitive_message() {
+    let err = input_load_error(InputErrorReason::ClipboardPrimitive);
+    match err {
+        JiqError::Io(msg) => {
+            assert!(msg.contains("non-JSON value"));
+            assert!(msg.contains("object or array"));
+            // No literal echo of the clipboard contents (privacy).
+            assert!(!msg.contains("`42`"));
+        }
+        other => panic!("expected JiqError::Io, got {:?}", other),
+    }
+}
+
+// ============================================================================
 // JSONL Validation Tests
 // ============================================================================
 

--- a/src/input/paste_recovery.rs
+++ b/src/input/paste_recovery.rs
@@ -27,26 +27,63 @@ use super::loader::scan_json_or_jsonl;
 pub const PASTE_RECOVERY_MAX_BYTES: usize = 16 * 1024 * 1024;
 
 /// Banner text shown above the textarea when the user enters paste-
-/// recovery deliberately (via `--paste` flag or the smart picker's Paste
-/// option), as opposed to the failure-recovery path. Single source of
-/// truth so Phase 2's `new_explicit` constructor and any future
+/// recovery deliberately (via `--paste` flag or the source picker's
+/// Paste option), as opposed to the failure-recovery path. Single
+/// source of truth so the `new_explicit` constructor and any future
 /// caller stay in sync.
-#[allow(dead_code)] // Wired in Phase 2 (--paste UI).
 pub const EXPLICIT_PASTE_BANNER: &str = "Paste JSON below and press Enter to load.";
+
+/// Why paste-recovery is on screen.
+///
+/// `Recovery` is the existing failure-recovery path: clipboard couldn't
+/// be read, came back empty, or contained invalid/primitive JSON. We
+/// render with a red error border and a "No JSON loaded" title because
+/// something *did* go wrong.
+///
+/// `Explicit` is the user deliberately asking for paste mode (via
+/// `--paste` or the source picker's Paste option). Nothing has failed;
+/// render with a calm cyan border and a neutral "Paste JSON" title so
+/// it doesn't look like an error screen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PasteRecoveryMode {
+    Recovery,
+    Explicit,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PasteRecoveryState {
-    /// Top-of-screen error message. Starts as the loader's diagnosis line
-    /// (e.g. "Clipboard does not contain valid JSON.") and is replaced by
-    /// the parse error after a failed submit attempt
-    /// ("Invalid JSON: expected `,` at line 3 column 5").
+    /// Top-of-screen message. In `Recovery` mode this starts as the
+    /// loader's diagnosis line (e.g. "Clipboard does not contain valid
+    /// JSON.") and is replaced by the parse error after a failed
+    /// submit ("Invalid JSON: expected `,` at line 3 column 5"). In
+    /// `Explicit` mode it starts as [`EXPLICIT_PASTE_BANNER`] and is
+    /// only replaced when a parse fails.
     pub error_message: String,
+    /// Whether the user landed here from a clipboard failure
+    /// (`Recovery`) or asked for paste explicitly (`Explicit`). Drives
+    /// the renderer's title / border color choice.
+    pub mode: PasteRecoveryMode,
 }
 
 impl PasteRecoveryState {
+    /// Construct a recovery-mode state — used when something went
+    /// wrong reading the clipboard. `error_message` is shown in the
+    /// red top block.
     pub fn new(error_message: impl Into<String>) -> Self {
         Self {
             error_message: error_message.into(),
+            mode: PasteRecoveryMode::Recovery,
+        }
+    }
+
+    /// Construct an explicit-paste state — used when the user asked
+    /// for paste mode deliberately (via `--paste` or the picker's
+    /// Paste option). Top block shows [`EXPLICIT_PASTE_BANNER`] until
+    /// a parse error replaces it.
+    pub fn new_explicit() -> Self {
+        Self {
+            error_message: EXPLICIT_PASTE_BANNER.to_string(),
+            mode: PasteRecoveryMode::Explicit,
         }
     }
 

--- a/src/input/paste_recovery.rs
+++ b/src/input/paste_recovery.rs
@@ -19,12 +19,20 @@
 
 use crate::error::JiqError;
 
-use super::loader::validate_json_or_jsonl;
+use super::loader::scan_json_or_jsonl;
 
 /// Soft cap on pasted content. Larger pastes are rejected with a clear
 /// message rather than being shoved into the textarea (which would block
 /// the event loop on each insert).
 pub const PASTE_RECOVERY_MAX_BYTES: usize = 16 * 1024 * 1024;
+
+/// Banner text shown above the textarea when the user enters paste-
+/// recovery deliberately (via `--paste` flag or the smart picker's Paste
+/// option), as opposed to the failure-recovery path. Single source of
+/// truth so Phase 2's `new_explicit` constructor and any future
+/// caller stay in sync.
+#[allow(dead_code)] // Wired in Phase 2 (--paste UI).
+pub const EXPLICIT_PASTE_BANNER: &str = "Paste JSON below and press Enter to load.";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PasteRecoveryState {
@@ -55,8 +63,14 @@ impl PasteRecoveryState {
             return Err(msg);
         }
 
-        match validate_json_or_jsonl(content) {
-            Ok(()) => Ok(content.to_string()),
+        match scan_json_or_jsonl(content) {
+            Ok(scan) if scan.all_containers => Ok(content.to_string()),
+            Ok(_) => {
+                let msg =
+                    "Input must be a JSON object or array, not a primitive value.".to_string();
+                self.error_message = msg.clone();
+                Err(msg)
+            }
             Err(JiqError::InvalidJson(detail)) => {
                 let msg = format!("Invalid JSON: {}", detail);
                 self.error_message = msg.clone();

--- a/src/input/paste_recovery.rs
+++ b/src/input/paste_recovery.rs
@@ -26,13 +26,6 @@ use super::loader::scan_json_or_jsonl;
 /// the event loop on each insert).
 pub const PASTE_RECOVERY_MAX_BYTES: usize = 16 * 1024 * 1024;
 
-/// Banner text shown above the textarea when the user enters paste-
-/// recovery deliberately (via `--paste` flag or the source picker's
-/// Paste option), as opposed to the failure-recovery path. Single
-/// source of truth so the `new_explicit` constructor and any future
-/// caller stay in sync.
-pub const EXPLICIT_PASTE_BANNER: &str = "Paste JSON below and press Enter to load.";
-
 /// Why paste-recovery is on screen.
 ///
 /// `Recovery` is the existing failure-recovery path: clipboard couldn't
@@ -56,8 +49,13 @@ pub struct PasteRecoveryState {
     /// loader's diagnosis line (e.g. "Clipboard does not contain valid
     /// JSON.") and is replaced by the parse error after a failed
     /// submit ("Invalid JSON: expected `,` at line 3 column 5"). In
-    /// `Explicit` mode it starts as [`EXPLICIT_PASTE_BANNER`] and is
-    /// only replaced when a parse fails.
+    /// `Explicit` mode this is empty unless the picker's smart
+    /// fallback added a "why we're here" context line, or a parse
+    /// error replaced it.
+    ///
+    /// Empty string means "no info to show" — the renderer suppresses
+    /// the top block entirely when this is empty AND the mode is
+    /// `Explicit`, so the textarea claims the full screen.
     pub error_message: String,
     /// Whether the user landed here from a clipboard failure
     /// (`Recovery`) or asked for paste explicitly (`Explicit`). Drives
@@ -78,11 +76,28 @@ impl PasteRecoveryState {
 
     /// Construct an explicit-paste state — used when the user asked
     /// for paste mode deliberately (via `--paste` or the picker's
-    /// Paste option). Top block shows [`EXPLICIT_PASTE_BANNER`] until
-    /// a parse error replaces it.
+    /// Paste option). The top info block stays hidden because the
+    /// textarea's title and placeholder already say "Paste JSON,
+    /// press Enter to load"; an extra info box would just repeat that.
     pub fn new_explicit() -> Self {
         Self {
-            error_message: EXPLICIT_PASTE_BANNER.to_string(),
+            error_message: String::new(),
+            mode: PasteRecoveryMode::Explicit,
+        }
+    }
+
+    /// Like [`new_explicit`] but with a one-line context describing
+    /// why we landed here. Used when jiq jumps straight to the paste
+    /// editor because the clipboard wasn't usable on launch (e.g.
+    /// "Clipboard is empty — paste below to load."). When `context` is
+    /// `None` or empty, behaves exactly like [`new_explicit`].
+    pub fn new_explicit_with_context(context: Option<&str>) -> Self {
+        let message = match context {
+            Some(line) if !line.is_empty() => line.to_string(),
+            _ => String::new(),
+        };
+        Self {
+            error_message: message,
             mode: PasteRecoveryMode::Explicit,
         }
     }

--- a/src/input/paste_recovery_tests.rs
+++ b/src/input/paste_recovery_tests.rs
@@ -36,6 +36,56 @@ fn try_submit_with_embedded_newlines_in_strings() {
     assert!(state.try_submit(r#"{"a": "line1\nline2"}"#).is_ok());
 }
 
+// ============================================================================
+// Primitive-guard tests (Phase 1 — H2)
+//
+// Manual paste must reject bare primitives (42, "foo", true, null) for the
+// same reason clipboard load does: jq queries operate on objects/arrays.
+// Both paths use the shared `scan_json_or_jsonl` helper.
+// ============================================================================
+
+#[test]
+fn try_submit_rejects_bare_number() {
+    let mut state = PasteRecoveryState::new("err");
+    let result = state.try_submit("42");
+    assert!(result.is_err());
+    assert!(
+        state.error_message.contains("object or array"),
+        "got: {}",
+        state.error_message
+    );
+}
+
+#[test]
+fn try_submit_rejects_bare_string() {
+    let mut state = PasteRecoveryState::new("err");
+    assert!(state.try_submit(r#""hello""#).is_err());
+}
+
+#[test]
+fn try_submit_rejects_bare_bool() {
+    let mut state = PasteRecoveryState::new("err");
+    assert!(state.try_submit("true").is_err());
+}
+
+#[test]
+fn try_submit_rejects_bare_null() {
+    let mut state = PasteRecoveryState::new("err");
+    assert!(state.try_submit("null").is_err());
+}
+
+#[test]
+fn try_submit_rejects_jsonl_with_one_primitive() {
+    let mut state = PasteRecoveryState::new("err");
+    let result = state.try_submit("{\"a\": 1}\n42");
+    assert!(result.is_err());
+    assert!(
+        state.error_message.contains("object or array"),
+        "got: {}",
+        state.error_message
+    );
+}
+
 #[test]
 fn try_submit_with_invalid_json_updates_error_message() {
     let mut state = PasteRecoveryState::new("original error");

--- a/src/input/paste_recovery_tests.rs
+++ b/src/input/paste_recovery_tests.rs
@@ -7,6 +7,46 @@ fn new_stores_error_message() {
     assert_eq!(state.error_message, "Clipboard is empty.");
 }
 
+// ============================================================================
+// Explicit-paste constructor (`new_explicit`) and mode discriminator.
+// ============================================================================
+
+#[test]
+fn new_recovery_mode_is_default() {
+    let state = PasteRecoveryState::new("err");
+    assert_eq!(state.mode, PasteRecoveryMode::Recovery);
+}
+
+#[test]
+fn new_explicit_uses_explicit_mode() {
+    let state = PasteRecoveryState::new_explicit();
+    assert_eq!(state.mode, PasteRecoveryMode::Explicit);
+}
+
+#[test]
+fn new_explicit_uses_banner_constant() {
+    let state = PasteRecoveryState::new_explicit();
+    assert_eq!(state.error_message, EXPLICIT_PASTE_BANNER);
+}
+
+#[test]
+fn try_submit_preserves_explicit_mode_on_failure() {
+    // A failed submit replaces error_message but must NOT flip the
+    // mode discriminator. The renderer keys off `mode` for styling, so
+    // a parse failure on an --paste invocation should still render in
+    // explicit (cyan) styling, not flip to recovery (red).
+    let mut state = PasteRecoveryState::new_explicit();
+    let _ = state.try_submit(r#"{"a": invalid}"#);
+    assert_eq!(state.mode, PasteRecoveryMode::Explicit);
+}
+
+#[test]
+fn try_submit_preserves_recovery_mode_on_failure() {
+    let mut state = PasteRecoveryState::new("clipboard failed");
+    let _ = state.try_submit(r#"{"a": invalid}"#);
+    assert_eq!(state.mode, PasteRecoveryMode::Recovery);
+}
+
 #[test]
 fn try_submit_with_valid_json_object_returns_ok() {
     let mut state = PasteRecoveryState::new("err");
@@ -37,7 +77,7 @@ fn try_submit_with_embedded_newlines_in_strings() {
 }
 
 // ============================================================================
-// Primitive-guard tests (Phase 1 — H2)
+// Primitive-guard tests.
 //
 // Manual paste must reject bare primitives (42, "foo", true, null) for the
 // same reason clipboard load does: jq queries operate on objects/arrays.

--- a/src/input/paste_recovery_tests.rs
+++ b/src/input/paste_recovery_tests.rs
@@ -24,9 +24,23 @@ fn new_explicit_uses_explicit_mode() {
 }
 
 #[test]
-fn new_explicit_uses_banner_constant() {
+fn new_explicit_has_empty_message() {
+    // No info to show on plain --paste; the renderer suppresses the
+    // top block and the textarea claims the full screen.
     let state = PasteRecoveryState::new_explicit();
-    assert_eq!(state.error_message, EXPLICIT_PASTE_BANNER);
+    assert!(state.error_message.is_empty());
+}
+
+#[test]
+fn new_explicit_with_context_carries_context() {
+    let state = PasteRecoveryState::new_explicit_with_context(Some("Clipboard is empty."));
+    assert_eq!(state.error_message, "Clipboard is empty.");
+}
+
+#[test]
+fn new_explicit_with_context_none_is_empty() {
+    let state = PasteRecoveryState::new_explicit_with_context(None);
+    assert!(state.error_message.is_empty());
 }
 
 #[test]

--- a/src/input/source_picker.rs
+++ b/src/input/source_picker.rs
@@ -1,0 +1,77 @@
+//! Source picker state.
+//!
+//! Shown on bare TTY launch (no file argument, no piped stdin, no
+//! `--clipboard` / `--paste`) to ask the user where jiq should read
+//! JSON from. The clipboard is peeked once at launch so the default
+//! selection reflects what's actually available:
+//! * Clipboard parses as object/array → default-select Clipboard, show
+//!   a preview pane sourced from the cached bytes.
+//! * Anything else → default-select Paste, show a one-line failure
+//!   context (clipboard unreadable / empty / invalid / primitive).
+//!
+//! The cached bytes are handed to [`crate::input::FileLoader::from_clipboard_string`]
+//! on confirm, so the actual load path never re-reads the clipboard.
+
+use crate::input::loader::ClipboardPeek;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceChoice {
+    Clipboard,
+    Paste,
+}
+
+#[derive(Debug)]
+pub struct SourcePickerState {
+    /// Currently highlighted option. Mutated by the key handler / mouse
+    /// hover; consumed on confirm to pick the load path.
+    pub selection: SourceChoice,
+    /// Cached clipboard bytes from the launch-time peek. Present iff
+    /// the peek returned `Usable`. Consumed on Clipboard-confirm; the
+    /// loader never re-reads the system clipboard.
+    pub clipboard_cache: Option<String>,
+    /// Snapshot of the launch-time peek outcome. Drives the rendered
+    /// preview pane and the failure-context line. Refreshed when the
+    /// user hits the manual-refresh key.
+    pub peek: ClipboardPeek,
+}
+
+impl SourcePickerState {
+    /// Build a picker from a launch-time clipboard peek. Pre-selection
+    /// is data-driven: usable clipboard → Clipboard; anything else →
+    /// Paste, so the default choice always matches reality.
+    pub fn from_peek(peek: ClipboardPeek) -> Self {
+        let (selection, clipboard_cache) = match &peek {
+            ClipboardPeek::Usable(bytes) => (SourceChoice::Clipboard, Some(bytes.clone())),
+            _ => (SourceChoice::Paste, None),
+        };
+        Self {
+            selection,
+            clipboard_cache,
+            peek,
+        }
+    }
+
+    /// Move the highlight to the next option. Two options today, but
+    /// the cycle is encoded explicitly so an added third source would
+    /// preserve direction-of-travel rather than silently aliasing
+    /// `select_previous`.
+    pub fn select_next(&mut self) {
+        self.selection = match self.selection {
+            SourceChoice::Clipboard => SourceChoice::Paste,
+            SourceChoice::Paste => SourceChoice::Clipboard,
+        };
+    }
+
+    /// Move the highlight to the previous option. Inverse cycle of
+    /// [`select_next`].
+    pub fn select_previous(&mut self) {
+        self.selection = match self.selection {
+            SourceChoice::Clipboard => SourceChoice::Paste,
+            SourceChoice::Paste => SourceChoice::Clipboard,
+        };
+    }
+}
+
+#[cfg(test)]
+#[path = "source_picker_tests.rs"]
+mod source_picker_tests;

--- a/src/input/source_picker_tests.rs
+++ b/src/input/source_picker_tests.rs
@@ -1,0 +1,66 @@
+use super::*;
+
+fn usable(text: &str) -> ClipboardPeek {
+    ClipboardPeek::Usable(text.to_string())
+}
+
+#[test]
+fn from_peek_usable_clipboard_preselects_clipboard_and_caches_bytes() {
+    let state = SourcePickerState::from_peek(usable(r#"{"a": 1}"#));
+    assert_eq!(state.selection, SourceChoice::Clipboard);
+    assert_eq!(state.clipboard_cache.as_deref(), Some(r#"{"a": 1}"#));
+}
+
+#[test]
+fn from_peek_unreadable_preselects_paste_and_no_cache() {
+    let state = SourcePickerState::from_peek(ClipboardPeek::Unreadable);
+    assert_eq!(state.selection, SourceChoice::Paste);
+    assert!(state.clipboard_cache.is_none());
+}
+
+#[test]
+fn from_peek_empty_preselects_paste() {
+    let state = SourcePickerState::from_peek(ClipboardPeek::Empty);
+    assert_eq!(state.selection, SourceChoice::Paste);
+    assert!(state.clipboard_cache.is_none());
+}
+
+#[test]
+fn from_peek_invalid_preselects_paste() {
+    let state = SourcePickerState::from_peek(ClipboardPeek::Invalid);
+    assert_eq!(state.selection, SourceChoice::Paste);
+}
+
+#[test]
+fn from_peek_primitive_preselects_paste() {
+    let state = SourcePickerState::from_peek(ClipboardPeek::Primitive);
+    assert_eq!(state.selection, SourceChoice::Paste);
+}
+
+#[test]
+fn select_next_cycles_clipboard_to_paste_to_clipboard() {
+    let mut state = SourcePickerState::from_peek(usable(r#"{}"#));
+    assert_eq!(state.selection, SourceChoice::Clipboard);
+    state.select_next();
+    assert_eq!(state.selection, SourceChoice::Paste);
+    state.select_next();
+    assert_eq!(state.selection, SourceChoice::Clipboard);
+}
+
+#[test]
+fn select_previous_is_inverse_cycle() {
+    let mut state = SourcePickerState::from_peek(usable(r#"{}"#));
+    state.select_previous();
+    assert_eq!(state.selection, SourceChoice::Paste);
+    state.select_previous();
+    assert_eq!(state.selection, SourceChoice::Clipboard);
+}
+
+#[test]
+fn failure_context_only_when_unusable() {
+    assert!(usable(r#"{}"#).failure_context().is_none());
+    assert!(ClipboardPeek::Empty.failure_context().is_some());
+    assert!(ClipboardPeek::Invalid.failure_context().is_some());
+    assert!(ClipboardPeek::Primitive.failure_context().is_some());
+    assert!(ClipboardPeek::Unreadable.failure_context().is_some());
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,19 @@ struct Args {
     /// Input JSON file (if not provided, reads from stdin)
     input: Option<PathBuf>,
 
+    /// Force reading JSON from the system clipboard. Mutually exclusive
+    /// with --paste; cannot be combined with piped stdin (the
+    /// invocation is contradictory and is rejected with exit code 2).
+    #[arg(long, conflicts_with = "paste")]
+    clipboard: bool,
+
+    /// Drop straight into manual-paste mode without reading the
+    /// clipboard. Mutually exclusive with --clipboard; cannot be
+    /// combined with piped stdin (rejected with exit code 2). No-op
+    /// until the explicit-paste UI lands in Phase 2.
+    #[arg(long, conflicts_with = "clipboard")]
+    paste: bool,
+
     /// Enable debug logging to /tmp/jiq-debug.log
     #[arg(long)]
     debug: bool,
@@ -75,9 +88,53 @@ fn main() -> Result<()> {
     validate_jq_exists()?;
     log::debug!("jq binary found in PATH");
 
+    // H1 hard-error: an explicit source flag combined with ANY other
+    // source is contradictory. The user typed `--clipboard` / `--paste`
+    // to override the default; a file argument or piped stdin
+    // contradicts the override. Refuse to launch rather than silently
+    // dropping one.
+    //
+    // (clap already rejects --clipboard + --paste at parse time via
+    // conflicts_with, so we don't need to check that combination here.)
+    //
+    // We deliberately do NOT trip on `file + piped stdin` without a
+    // flag. That preserves today's behavior (file arg wins) for
+    // scripts/CI invocations where stdin happens to be redirected
+    // (e.g. `jiq foo.json < /dev/null` from cron).
+    //
+    // Runs *before* init_terminal so the message lands on the user's
+    // normal terminal, not inside the alt screen.
+    let has_file = args.input.is_some();
+    let has_pipe = !std::io::IsTerminal::is_terminal(&std::io::stdin());
+    let flag: Option<&str> = if args.clipboard {
+        Some("--clipboard")
+    } else if args.paste {
+        Some("--paste")
+    } else {
+        None
+    };
+    if let Some(f) = flag
+        && (has_file || has_pipe)
+    {
+        let mut got = Vec::with_capacity(3);
+        if has_file {
+            got.push("a file argument".to_string());
+        }
+        if has_pipe {
+            got.push("piped stdin".to_string());
+        }
+        got.push(f.to_string());
+        print_ambiguous_source_error(&got);
+        std::process::exit(2);
+    }
+
     // Clipboard fallback runs *before* init_terminal so OSC 52 read can briefly
     // own raw stdin without racing the main event loop. File and stdin paths
     // stay deferred so a large input never blocks the splash screen.
+    //
+    // `--paste` is parsed but a no-op in Phase 1 — bare TTY plus
+    // `--paste` falls through to the same clipboard read as today,
+    // pending Phase 2's explicit-paste UI.
     let loader = if let Some(ref path) = args.input {
         log::debug!("File loader spawned for: {:?}", path);
         FileLoader::spawn_load(path.clone())
@@ -109,6 +166,52 @@ fn main() -> Result<()> {
 fn validate_jq_exists() -> Result<(), JiqError> {
     which::which("jq").map_err(|_| JiqError::JqNotFound)?;
     Ok(())
+}
+
+/// Render the H1 "ambiguous input source" error to stderr with ANSI
+/// colors when stderr is a TTY, plain text otherwise (so redirecting
+/// `2>file` produces clean output without escape codes). Colors mirror
+/// the rest of jiq's palette: red for the error label, yellow for the
+/// rejected sources, dim for shell-comments, bold for the heading.
+///
+/// `got` is the list of sources jiq detected on this invocation
+/// (file argument / piped stdin / `--clipboard` / `--paste`); jiq
+/// accepts at most one, so any list of length ≥ 2 trips this error.
+fn print_ambiguous_source_error(got: &[String]) {
+    let tty = std::io::IsTerminal::is_terminal(&std::io::stderr());
+
+    // ANSI escapes — only emitted when stderr is a TTY.
+    let (red, yellow, cyan, dim, bold, reset) = if tty {
+        (
+            "\x1b[31m", "\x1b[33m", "\x1b[36m", "\x1b[2m", "\x1b[1m", "\x1b[0m",
+        )
+    } else {
+        ("", "", "", "", "", "")
+    };
+
+    let got_list = match got.len() {
+        0 | 1 => unreachable!("ambiguous error requires at least 2 sources"),
+        2 => format!("{yellow}{}{reset} AND {yellow}{}{reset}", got[0], got[1]),
+        _ => {
+            let last = got.len() - 1;
+            let head = got[..last]
+                .iter()
+                .map(|s| format!("{yellow}{s}{reset}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{head}, AND {yellow}{}{reset}", got[last])
+        }
+    };
+
+    eprintln!(
+        "{bold}{red}error:{reset}{bold} ambiguous input source{reset} — got {got_list} at the same time.\n\n\
+         jiq accepts exactly one input source per invocation. Pick one:\n\
+         \x20 {cyan}jiq <file>{reset}            {dim}# load from a file{reset}\n\
+         \x20 {cyan}cat <file> | jiq{reset}      {dim}# load from piped stdin{reset}\n\
+         \x20 {cyan}jiq{reset}                   {dim}# load from system clipboard (default){reset}\n\
+         \x20 {cyan}jiq --clipboard{reset}       {dim}# load from system clipboard (explicit){reset}\n\
+         \x20 {cyan}jiq --paste{reset}           {dim}# open the manual-paste editor{reset}"
+    );
 }
 
 /// Initialize terminal with raw mode, alternate screen, and bracketed paste

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,8 @@ mod widgets;
 
 use app::{App, OutputMode};
 use error::JiqError;
-use input::{FileLoader, PasteRecoveryState};
+use input::loader::peek_clipboard;
+use input::{FileLoader, PasteRecoveryState, SourcePickerState};
 use query::executor::JqExecutor;
 
 /// Interactive JSON query tool
@@ -144,6 +145,7 @@ fn main() -> Result<()> {
         PreInput::PasteRecovery(state) => {
             App::new_with_paste_recovery(state, &config_result.config)
         }
+        PreInput::Picker(state) => App::new_with_source_picker(state, &config_result.config),
     };
     let result = run(terminal, app, config_result);
 
@@ -164,19 +166,30 @@ fn validate_jq_exists() -> Result<(), JiqError> {
     Ok(())
 }
 
-/// What jiq has lined up before the TUI starts: either a `FileLoader`
-/// (file/stdin/clipboard) or an explicit paste-recovery state. Resolved
-/// pre-init so any blocking clipboard read happens before crossterm's
-/// raw-mode + bracketed-paste handshake.
+/// What jiq has lined up before the TUI starts: a deferred file/stdin
+/// loader, an immediate paste-recovery editor, or the source picker.
+/// Resolved pre-init so any blocking clipboard read happens before
+/// crossterm's raw-mode + bracketed-paste handshake.
 enum PreInput {
     Loader(FileLoader),
     PasteRecovery(PasteRecoveryState),
+    Picker(SourcePickerState),
 }
 
 /// Decide which pre-input the user asked for and produce it. Runs
-/// before `init_terminal()` because the clipboard branch may briefly
-/// own raw stdin (OSC 52 fallback); doing this after init would wipe
-/// the terminal's bracketed-paste mode for the rest of the session.
+/// before `init_terminal()` because the clipboard read (whether for
+/// the picker peek or `--clipboard` direct load) may briefly own raw
+/// stdin via the OSC 52 fallback; doing this after init would wipe
+/// bracketed-paste support for the rest of the session.
+///
+/// On bare TTY launches we peek the clipboard once, then choose
+/// between the picker and a direct-to-paste shortcut: showing the
+/// picker only makes sense when the Clipboard option is actually
+/// usable. If the clipboard is unreadable / empty / invalid /
+/// primitive, the Clipboard option can't be confirmed anyway, so we
+/// skip the chooser entirely and drop straight into the explicit-paste
+/// editor with a context line explaining what jiq saw on the
+/// clipboard.
 fn resolve_pre_input(args: &Args) -> PreInput {
     if args.paste {
         log::debug!("Entering explicit paste mode (--paste)");
@@ -190,8 +203,20 @@ fn resolve_pre_input(args: &Args) -> PreInput {
         log::debug!("File loader spawned for stdin");
         return PreInput::Loader(FileLoader::spawn_load_stdin());
     }
-    log::debug!("Loading clipboard synchronously (no argument, no piped stdin)");
-    PreInput::Loader(FileLoader::load_clipboard_blocking())
+    if args.clipboard {
+        log::debug!("Loading clipboard synchronously (forced via --clipboard)");
+        return PreInput::Loader(FileLoader::load_clipboard_blocking());
+    }
+    log::debug!("Bare TTY launch — peeking clipboard for source picker");
+    let peek = peek_clipboard();
+    if peek.is_usable() {
+        PreInput::Picker(SourcePickerState::from_peek(peek))
+    } else {
+        log::debug!("Clipboard not usable; jumping straight to explicit paste");
+        PreInput::PasteRecovery(PasteRecoveryState::new_explicit_with_context(
+            peek.failure_context(),
+        ))
+    }
 }
 
 /// Render the H1 "ambiguous input source" error to stderr with ANSI

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ mod widgets;
 
 use app::{App, OutputMode};
 use error::JiqError;
-use input::FileLoader;
+use input::{FileLoader, PasteRecoveryState};
 use query::executor::JqExecutor;
 
 /// Interactive JSON query tool
@@ -65,8 +65,7 @@ struct Args {
 
     /// Drop straight into manual-paste mode without reading the
     /// clipboard. Mutually exclusive with --clipboard; cannot be
-    /// combined with piped stdin (rejected with exit code 2). No-op
-    /// until the explicit-paste UI lands in Phase 2.
+    /// combined with piped stdin (rejected with exit code 2).
     #[arg(long, conflicts_with = "clipboard")]
     paste: bool,
 
@@ -128,27 +127,24 @@ fn main() -> Result<()> {
         std::process::exit(2);
     }
 
-    // Clipboard fallback runs *before* init_terminal so OSC 52 read can briefly
-    // own raw stdin without racing the main event loop. File and stdin paths
-    // stay deferred so a large input never blocks the splash screen.
+    // Resolve the input source before `init_terminal()`. Clipboard
+    // reads MUST happen pre-init: the OSC 52 fallback toggles raw mode
+    // around its read, and crossterm's `disable_raw_mode()` does not
+    // preserve `EnableBracketedPaste`. Doing the read after init would
+    // wipe bracketed-paste support for the rest of the session, which
+    // makes large pastes inside the recovery textarea arrive byte by
+    // byte instead of as a single `Event::Paste`.
     //
-    // `--paste` is parsed but a no-op in Phase 1 — bare TTY plus
-    // `--paste` falls through to the same clipboard read as today,
-    // pending Phase 2's explicit-paste UI.
-    let loader = if let Some(ref path) = args.input {
-        log::debug!("File loader spawned for: {:?}", path);
-        FileLoader::spawn_load(path.clone())
-    } else if !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
-        log::debug!("File loader spawned for stdin");
-        FileLoader::spawn_load_stdin()
-    } else {
-        log::debug!("Loading clipboard synchronously (no argument, no piped stdin)");
-        FileLoader::load_clipboard_blocking()
-    };
-
+    // File and stdin loads stay deferred so a large input never blocks
+    // the splash. `--paste` skips the clipboard entirely.
+    let pre_input = resolve_pre_input(&args);
     let terminal = init_terminal()?;
-
-    let app = App::new_with_loader(loader, &config_result.config);
+    let app = match pre_input {
+        PreInput::Loader(loader) => App::new_with_loader(loader, &config_result.config),
+        PreInput::PasteRecovery(state) => {
+            App::new_with_paste_recovery(state, &config_result.config)
+        }
+    };
     let result = run(terminal, app, config_result);
 
     restore_terminal()?;
@@ -166,6 +162,36 @@ fn main() -> Result<()> {
 fn validate_jq_exists() -> Result<(), JiqError> {
     which::which("jq").map_err(|_| JiqError::JqNotFound)?;
     Ok(())
+}
+
+/// What jiq has lined up before the TUI starts: either a `FileLoader`
+/// (file/stdin/clipboard) or an explicit paste-recovery state. Resolved
+/// pre-init so any blocking clipboard read happens before crossterm's
+/// raw-mode + bracketed-paste handshake.
+enum PreInput {
+    Loader(FileLoader),
+    PasteRecovery(PasteRecoveryState),
+}
+
+/// Decide which pre-input the user asked for and produce it. Runs
+/// before `init_terminal()` because the clipboard branch may briefly
+/// own raw stdin (OSC 52 fallback); doing this after init would wipe
+/// the terminal's bracketed-paste mode for the rest of the session.
+fn resolve_pre_input(args: &Args) -> PreInput {
+    if args.paste {
+        log::debug!("Entering explicit paste mode (--paste)");
+        return PreInput::PasteRecovery(PasteRecoveryState::new_explicit());
+    }
+    if let Some(ref path) = args.input {
+        log::debug!("File loader spawned for: {:?}", path);
+        return PreInput::Loader(FileLoader::spawn_load(path.clone()));
+    }
+    if !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+        log::debug!("File loader spawned for stdin");
+        return PreInput::Loader(FileLoader::spawn_load_stdin());
+    }
+    log::debug!("Loading clipboard synchronously (no argument, no piped stdin)");
+    PreInput::Loader(FileLoader::load_clipboard_blocking())
 }
 
 /// Render the H1 "ambiguous input source" error to stderr with ANSI

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -67,6 +67,106 @@ fn test_cli_version_flag() {
         .stdout(predicate::str::contains("jiq"));
 }
 
+// ============================================================================
+// Phase 1 — H1 hard-error: --clipboard / --paste with piped stdin
+//
+// Piped stdin combined with an explicit source flag is contradictory; jiq
+// refuses to launch and exits with code 2. The error must land on stderr
+// before the alt screen is entered, so the message is visible in the
+// user's normal terminal.
+// ============================================================================
+
+#[test]
+fn test_cli_clipboard_with_piped_stdin_errors() {
+    cargo_bin_cmd!()
+        .arg("--clipboard")
+        .write_stdin(r#"{"a": 1}"#)
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("ambiguous input source"))
+        .stderr(predicate::str::contains("--clipboard"))
+        .stderr(predicate::str::contains("piped stdin"))
+        // Error must list the valid invocations so the user can pick one.
+        .stderr(predicate::str::contains("jiq <file>"))
+        .stderr(predicate::str::contains("cat <file> | jiq"))
+        .stderr(predicate::str::contains("jiq --paste"));
+}
+
+#[test]
+fn test_cli_paste_with_piped_stdin_errors() {
+    cargo_bin_cmd!()
+        .arg("--paste")
+        .write_stdin(r#"{"a": 1}"#)
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("ambiguous input source"))
+        .stderr(predicate::str::contains("--paste"))
+        .stderr(predicate::str::contains("piped stdin"));
+}
+
+#[test]
+fn test_cli_file_with_clipboard_flag_errors() {
+    let fixture = fixture_path("simple.json");
+    // assert_cmd always pipes stdin, so "piped stdin" will also be
+    // listed alongside the file arg + flag. The user-facing case from
+    // a real terminal is just "a file argument AND --clipboard".
+    cargo_bin_cmd!()
+        .arg(&fixture)
+        .arg("--clipboard")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("ambiguous input source"))
+        .stderr(predicate::str::contains("file argument"))
+        .stderr(predicate::str::contains("--clipboard"));
+}
+
+#[test]
+fn test_cli_file_with_paste_flag_errors() {
+    let fixture = fixture_path("simple.json");
+    cargo_bin_cmd!()
+        .arg(&fixture)
+        .arg("--paste")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("ambiguous input source"))
+        .stderr(predicate::str::contains("file argument"))
+        .stderr(predicate::str::contains("--paste"));
+}
+
+#[test]
+fn test_cli_file_with_piped_stdin_does_not_error() {
+    // No flag involved → file wins, piped stdin is ignored. Preserves
+    // today's behavior for scripts where stdin is redirected (e.g.
+    // `jiq foo.json < /dev/null` from cron). Only the new ambiguous
+    // case (file + flag, with or without pipe) errors out.
+    //
+    // We can't easily assert success here because the binary boots into
+    // the TUI; just confirm we don't get the H1 error message.
+    let fixture = fixture_path("simple.json");
+    let assert = cargo_bin_cmd!()
+        .arg(&fixture)
+        .write_stdin(r#"{"a": 1}"#)
+        .timeout(std::time::Duration::from_millis(100))
+        .assert();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    assert!(
+        !stderr.contains("ambiguous input source"),
+        "did not expect ambiguous-source error, got stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_cli_clipboard_and_paste_mutually_exclusive() {
+    // clap should reject this at parse time (conflicts_with), so exit
+    // code is non-zero and stderr mentions both flags.
+    cargo_bin_cmd!()
+        .args(["--clipboard", "--paste"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--paste").or(predicate::str::contains("--clipboard")));
+}
+
 #[test]
 fn test_fixture_files_exist() {
     // Verify all our test fixtures are present

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -68,12 +68,12 @@ fn test_cli_version_flag() {
 }
 
 // ============================================================================
-// Phase 1 — H1 hard-error: --clipboard / --paste with piped stdin
+// Ambiguous input source — hard-error.
 //
-// Piped stdin combined with an explicit source flag is contradictory; jiq
-// refuses to launch and exits with code 2. The error must land on stderr
-// before the alt screen is entered, so the message is visible in the
-// user's normal terminal.
+// `--clipboard` / `--paste` combined with another input source (file argument
+// or piped stdin) is contradictory; jiq refuses to launch and exits with
+// code 2. The error must land on stderr before the alt screen is entered,
+// so the message is visible in the user's normal terminal.
 // ============================================================================
 
 #[test]


### PR DESCRIPTION
## Summary

- **Phase 1** (already shipped in `7ea1436`) added `--clipboard` / `--paste` flags, the primitive guard for manual paste, and a hard-error when piped stdin and a source flag are passed at the same time.
- **Phase 2** wires `--paste` to a neutral cyan paste-editor view (no more red "No JSON loaded" framing for an explicit user choice).
- **Phase 3** replaces the auto-clipboard-load-on-launch with a smart source picker: when bare `jiq` runs on a TTY, the clipboard is peeked once and either (a) the picker is shown with Clipboard pre-selected and a preview pane, or (b) jiq drops straight into the paste editor with a one-line context describing what was wrong with the clipboard.
- Top "Info" box on the paste editor is suppressed when there's nothing new to say (plain `--paste`); when shown, it never repeats instructions the textarea title/placeholder already convey.
- Clipboard fallback messages reworked to be terse, factual, and non-redundant.

## Test plan

- [x] cargo test
- [x] cargo build --release
- [x] cargo clippy --all-targets --all-features
- [x] cargo fmt --all --check
- [x] Manual TUI validation across: bare jiq with usable clipboard, with empty clipboard, with primitive (`42`) on clipboard, with invalid JSON on clipboard, `--paste` flag, `--clipboard` flag, file argument, piped stdin, ambiguous source combinations