### PR TITLE
feat(help-line): show Ctrl+O Copy Result hint when input focused

### DIFF
--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_error_overlay.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_error_overlay.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
-assertion_line: 144
 expression: output
 ---
 "╭   ⚠ Syntax Error   Object | Showing last successful result ──────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰─────────────── Shift+Tab Navigate Results • Ctrl+E Show Error ───────────────╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_initial_ui_empty_query.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_initial_ui_empty_query.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
-assertion_line: 16
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_results_pane_with_success_unfocused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_results_pane_with_success_unfocused.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
-assertion_line: 197
 expression: output
 ---
 "╭ String ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
 "╰─── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_results_pane_with_syntax_error_unfocused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_results_pane_with_syntax_error_unfocused.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
-assertion_line: 163
 expression: output
 ---
 "╭   ⚠ Syntax Error   String | Showing last successful result ──────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid[                                                                     │"
 "╰─────────────── Shift+Tab Navigate Results • Ctrl+E Show Error ───────────────╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_stats_bar_error_shows_last_stats.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_stats_bar_error_shows_last_stats.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
-assertion_line: 254
 expression: output
 ---
 "╭   ⚠ Syntax Error   Array [5 numbers] | Showing last successful result ───────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid[                                                                     │"
 "╰─────────────── Shift+Tab Navigate Results • Ctrl+E Show Error ───────────────╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_stats_bar_object_unfocused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_stats_bar_object_unfocused.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
-assertion_line: 238
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_error_overlay_visible.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_error_overlay_visible.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
-assertion_line: 113
 expression: output
 ---
 "╭   ⚠ Syntax Error   Number | Showing last successful result ──────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.foo                                                                          │"
 "╰─────────────── Shift+Tab Navigate Results • Ctrl+E Show Error ───────────────╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_input_focused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_input_focused.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
-assertion_line: 50
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_insert_mode.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_insert_mode.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
-assertion_line: 70
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_normal_mode.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_normal_mode.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
-assertion_line: 80
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [NORMAL] (press 'i' to edit) ───────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1/? Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Outp"
+" F1/? Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_operator_mode.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_operator_mode.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
-assertion_line: 90
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [OPERATOR(d)] ──────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1/? Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Outp"
+" F1/? Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_wide_terminal.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_wide_terminal.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
-assertion_line: 131
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮"
@@ -32,4 +31,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                                                                      │"
 "╰────────────── Shift+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ───────────────╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output Query • Ctrl+C Quit                    "
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+Q Output Query • Ctrl+C Qui"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_with_array_data.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_with_array_data.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
-assertion_line: 40
 expression: output
 ---
 "╭ Stream [3] ──────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.[].name                                                                      │"
 "╰─── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_with_error.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_with_error.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
-assertion_line: 101
 expression: output
 ---
 "╭   ⚠ Syntax Error   Number | Showing last successful result ──────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.foo                                                                          │"
 "╰─────────────── Shift+Tab Navigate Results • Ctrl+E Show Error ───────────────╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_with_query.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_with_query.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
-assertion_line: 28
 expression: output
 ---
 "╭ String ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
 "╰─── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__error_handling_tests__snapshot_file_load_error_full_details_in_results_area.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__error_handling_tests__snapshot_file_load_error_full_details_in_results_area.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/error_handling_tests.rs
-assertion_line: 101
 expression: output
 ---
 "╭ Error ───────────────────────────────────────────────────────────────────────────────────────────────────────────────╮"
@@ -32,4 +31,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                                                                      │"
 "╰────────────── Shift+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ───────────────╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output Query • Ctrl+C Quit                    "
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+Q Output Query • Ctrl+C Qui"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__error_handling_tests__snapshot_file_load_error_with_notification.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__error_handling_tests__snapshot_file_load_error_with_notification.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/error_handling_tests.rs
-assertion_line: 78
 expression: output
 ---
 "╭ Error ───────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_autocomplete_popup_mixed_types.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_autocomplete_popup_mixed_types.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 150
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_autocomplete_popup_selected_item_with_signature.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_autocomplete_popup_selected_item_with_signature.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 128
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_autocomplete_popup_with_function_signatures.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_autocomplete_popup_with_function_signatures.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 100
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_help_popup.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_help_popup.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 61
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Que│                                                                    ║ant ╮"
 "│    ╰───── 1-7 Jump • Tab Next • h/l Switch • j/k Scroll • q Close ──────╯    │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_help_popup_with_ai_tab.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_help_popup_with_ai_tab.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 74
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Que│                                                                    │ant ╮"
 "│    ╰───── 1-7 Jump • Tab Next • h/l Switch • j/k Scroll • q Close ──────╯    │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 23
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup_no_matches.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup_no_matches.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 51
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup_scrolled_bottom.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup_scrolled_bottom.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 350
 expression: output
 ---
 "╭ History (20/20) ─────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup_scrolled_middle.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup_scrolled_middle.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 333
 expression: output
 ---
 "╭ History (20/20) ─────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup_with_search.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup_with_search.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 38
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_hint_disabled_on_function.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_hint_disabled_on_function.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 235
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ──────────────────────── Ctrl+T Tooltip • Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_no_ai_hint_when_ai_visible.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_no_ai_hint_when_ai_visible.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 285
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ──────────────────────────────────────────────────────────────╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_no_hint_disabled_no_function.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_no_hint_disabled_no_function.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 259
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_no_hint_enabled.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_no_hint_enabled.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 247
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_with_ai_hint.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_with_ai_hint.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 272
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_both_hints_when_tooltip_available.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_both_hints_when_tooltip_available.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 364
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ──────────────────────── Ctrl+T Tooltip • Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_no_hints_when_ai_visible.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_no_hints_when_ai_visible.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 398
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ──────────────────────────────────────────────────────────────╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_only_ai_hint_when_tooltip_active.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_only_ai_hint_when_tooltip_active.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 381
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_and_autocomplete_both_visible.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_and_autocomplete_both_visible.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 314
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮"
@@ -32,4 +31,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                                                                      │"
 "╰────────────── Shift+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ───────────────╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output Query • Ctrl+C Quit                    "
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+Q Output Query • Ctrl+C Qui"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_dismiss_hint.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_dismiss_hint.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 199
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮"
@@ -32,4 +31,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                                                                      │"
 "╰────────────── Shift+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ───────────────╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output Query • Ctrl+C Quit                    "
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+Q Output Query • Ctrl+C Qui"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_operator_alternative.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_operator_alternative.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 211
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮"
@@ -32,4 +31,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                                                                      │"
 "╰────────────── Shift+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ───────────────╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output Query • Ctrl+C Quit                    "
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+Q Output Query • Ctrl+C Qui"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_operator_update.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_operator_update.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 223
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮"
@@ -32,4 +31,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                                                                      │"
 "╰────────────── Shift+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ───────────────╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output Query • Ctrl+C Quit                    "
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+Q Output Query • Ctrl+C Qui"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_popup_positioning.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_popup_positioning.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 186
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮"
@@ -32,4 +31,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                                                                      │"
 "╰────────────── Shift+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ───────────────╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output Query • Ctrl+C Quit                    "
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+Q Output Query • Ctrl+C Qui"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_popup_with_all_fields.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_popup_with_all_fields.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 162
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮"
@@ -32,4 +31,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                                                                      │"
 "╰────────────── Shift+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ───────────────╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output Query • Ctrl+C Quit                    "
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+Q Output Query • Ctrl+C Qui"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_popup_without_tip.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_popup_without_tip.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
-assertion_line: 174
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮"
@@ -32,4 +31,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                                                                      │"
 "╰────────────── Shift+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ───────────────╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output Query • Ctrl+C Quit                    "
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+Q Output Query • Ctrl+C Qui"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_query_spinner_frame_0.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_query_spinner_frame_0.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/processing_tests.rs
-assertion_line: 21
 expression: output
 ---
 "╭⠋ Object ─────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
 "╰─── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_query_spinner_frame_64.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_query_spinner_frame_64.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/processing_tests.rs
-assertion_line: 53
 expression: output
 ---
 "╭⠇ Object ─────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
 "╰─── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_query_spinner_frame_8.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_query_spinner_frame_8.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/processing_tests.rs
-assertion_line: 37
 expression: output
 ---
 "╭⠙ Object ─────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
 "╰─── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_with_previous_result.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_with_previous_result.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/processing_tests.rs
-assertion_line: 74
 expression: output
 ---
 "╭⠹ String ─────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.age                                                                          │"
 "╰─── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_with_syntax_error.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_with_syntax_error.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/processing_tests.rs
-assertion_line: 97
 expression: output
 ---
 "╭⠸    ⚠ Syntax Error   String | Showing last successful result ────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid[                                                                     │"
 "╰─────────────── Shift+Tab Navigate Results • Ctrl+E Show Error ───────────────╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_empty_unfocused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_empty_unfocused.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/result_state_tests.rs
-assertion_line: 70
 expression: output
 ---
 "╭   ∅ No Results   Array [2 objects] | Showing last non-empty result ──────────────────────────────────────────────────╮"
@@ -32,4 +31,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.[] | select(.name == "nonexistent")                                                                                  │"
 "╰─────────────────────── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───────────────────────╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output Query • Ctrl+C Quit                    "
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+Q Output Query • Ctrl+C Qui"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_error_unfocused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_error_unfocused.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/result_state_tests.rs
-assertion_line: 98
 expression: output
 ---
 "╭   ⚠ Syntax Error   Object | Showing last successful result ──────────────────────────────────────────────────────────╮"
@@ -32,4 +31,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid syntax here                                                                                                  │"
 "╰─────────────────────────────────── Shift+Tab Navigate Results • Ctrl+E Show Error ───────────────────────────────────╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output Query • Ctrl+C Quit                    "
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+Q Output Query • Ctrl+C Qui"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_success_unfocused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_success_unfocused.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/app_render_tests/result_state_tests.rs
-assertion_line: 32
 expression: output
 ---
 "╭ Stream [3] ──────────────────────────────────────────────────────────────────────────────────────────────────────────╮"
@@ -32,4 +31,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.[].name                                                                                                              │"
 "╰─────────────────────── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───────────────────────╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output Query • Ctrl+C Quit                    "
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+Q Output Query • Ctrl+C Qui"

--- a/src/help/help_line_render.rs
+++ b/src/help/help_line_render.rs
@@ -26,11 +26,11 @@ fn get_context_hints(app: &App) -> Vec<(&'static str, &'static str)> {
     } else if app.snippets.is_visible() {
         hints!["F1/?" => "Help", "Esc" => "Close"]
     } else if app.focus == Focus::InputField && app.input.editor_mode == EditorMode::Insert {
-        hints!["F1" => "Help", "Ctrl+S" => "Snippets", "Ctrl+F" => "Search", "Enter" => "Output Result", "Ctrl+Q" => "Output Query", "Ctrl+C" => "Quit"]
+        hints!["F1" => "Help", "Ctrl+S" => "Snippets", "Ctrl+F" => "Search", "Enter" => "Output Result", "Ctrl+O" => "Copy Result", "Ctrl+Q" => "Output Query", "Ctrl+C" => "Quit"]
     } else if app.focus == Focus::ResultsPane {
         hints!["F1/?" => "Help", "Shift+Tab" => "Edit Query", "Ctrl+S" => "Snippets", "Ctrl+F" => "Search", "Ctrl+C" => "Quit"]
     } else {
-        hints!["F1/?" => "Help", "Ctrl+S" => "Snippets", "Ctrl+F" => "Search", "Enter" => "Output Result", "Ctrl+Q" => "Output Query", "Ctrl+C" => "Quit"]
+        hints!["F1/?" => "Help", "Ctrl+S" => "Snippets", "Ctrl+F" => "Search", "Enter" => "Output Result", "Ctrl+O" => "Copy Result", "Ctrl+Q" => "Output Query", "Ctrl+C" => "Quit"]
     }
 }
 

--- a/src/help/help_line_render_tests.rs
+++ b/src/help/help_line_render_tests.rs
@@ -30,7 +30,7 @@ fn snapshot_help_line_insert_mode_empty_query() {
     app.focus = Focus::InputField;
     app.input.editor_mode = EditorMode::Insert;
 
-    let output = render_help_line_to_string(&app, 120, 1);
+    let output = render_help_line_to_string(&app, 130, 1);
     assert_snapshot!(output);
 }
 
@@ -45,7 +45,7 @@ fn snapshot_help_line_insert_mode_with_query() {
         query_state.execute(".foo");
     }
 
-    let output = render_help_line_to_string(&app, 120, 1);
+    let output = render_help_line_to_string(&app, 130, 1);
     assert_snapshot!(output);
 }
 
@@ -55,7 +55,7 @@ fn snapshot_help_line_normal_mode() {
     app.focus = Focus::InputField;
     app.input.editor_mode = EditorMode::Normal;
 
-    let output = render_help_line_to_string(&app, 120, 1);
+    let output = render_help_line_to_string(&app, 130, 1);
     assert_snapshot!(output);
 }
 

--- a/src/help/snapshots/jiq__help__help_line_render__help_line_render_tests__snapshot_help_line_insert_mode_empty_query.snap
+++ b/src/help/snapshots/jiq__help__help_line_render__help_line_render_tests__snapshot_help_line_insert_mode_empty_query.snap
@@ -1,6 +1,5 @@
 ---
 source: src/help/help_line_render_tests.rs
-assertion_line: 34
 expression: output
 ---
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output Query • Ctrl+C Quit                    "
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+Q Output Query • Ctrl+C Quit         "

--- a/src/help/snapshots/jiq__help__help_line_render__help_line_render_tests__snapshot_help_line_insert_mode_with_query.snap
+++ b/src/help/snapshots/jiq__help__help_line_render__help_line_render_tests__snapshot_help_line_insert_mode_with_query.snap
@@ -1,6 +1,5 @@
 ---
 source: src/help/help_line_render_tests.rs
-assertion_line: 49
 expression: output
 ---
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output Query • Ctrl+C Quit                    "
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+Q Output Query • Ctrl+C Quit         "

--- a/src/help/snapshots/jiq__help__help_line_render__help_line_render_tests__snapshot_help_line_normal_mode.snap
+++ b/src/help/snapshots/jiq__help__help_line_render__help_line_render_tests__snapshot_help_line_normal_mode.snap
@@ -1,6 +1,5 @@
 ---
 source: src/help/help_line_render_tests.rs
-assertion_line: 59
 expression: output
 ---
-" F1/? Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output Query • Ctrl+C Quit                  "
+" F1/? Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+Q Output Query • Ctrl+C Quit       "

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_focused_insert_mode.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_focused_insert_mode.snap
@@ -1,6 +1,5 @@
 ---
 source: src/input/input_render_tests.rs
-assertion_line: 28
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
 "╰─── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_focused_normal_mode.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_focused_normal_mode.snap
@@ -1,6 +1,5 @@
 ---
 source: src/input/input_render_tests.rs
-assertion_line: 41
 expression: output
 ---
 "╭ Object ──────────────────────────────────────────────────────────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [NORMAL] (press 'i' to edit) ───────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
 "╰─── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───╯"
-" F1/? Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Outp"
+" F1/? Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy"

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_focused_with_syntax_error.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_focused_with_syntax_error.snap
@@ -1,6 +1,5 @@
 ---
 source: src/input/input_render_tests.rs
-assertion_line: 119
 expression: output
 ---
 "╭   ⚠ Syntax Error   Object | Showing last successful result ──────────────────╮"
@@ -26,4 +25,4 @@ expression: output
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid[                                                                     │"
 "╰─────────────── Shift+Tab Navigate Results • Ctrl+E Show Error ───────────────╯"
-" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+Q Output"
+" F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"


### PR DESCRIPTION
## Summary
- Add `Ctrl+O Copy Result` to the bottom hint row when the input/query bar is focused (Insert and Normal modes), so the existing always-copy-result shortcut is discoverable without opening F1 help.
- Bump `help_line_render` snapshot test widths from 120 to 130 cols so the full hint line is captured without trailing truncation.

## Test plan
- [x] cargo test (3339 passed)
- [x] cargo build --release
- [x] cargo clippy --all-targets --all-features (zero warnings)
- [x] cargo fmt --all --check
- [x] Manual TUI validation skipped — text-only change to a render hint row