### PR TITLE
feat(autocomplete): add string-value autocomplete in comparisons

### DIFF
--- a/src/app/app_state.rs
+++ b/src/app/app_state.rs
@@ -1,4 +1,5 @@
 use crate::ai::AiState;
+use crate::autocomplete::autocomplete_state::ValueMemo;
 use crate::autocomplete::{self, AutocompleteState};
 use crate::config::{ClipboardBackend, Config};
 use crate::help::HelpPopupState;
@@ -42,6 +43,7 @@ pub struct App {
     pub output_mode: Option<OutputMode>,
     pub should_quit: bool,
     pub autocomplete: AutocompleteState,
+    pub(crate) value_memo: ValueMemo,
     pub error_overlay_visible: bool,
     pub history: HistoryState,
     pub help: HelpPopupState,
@@ -187,6 +189,7 @@ impl App {
             output_mode: None,
             should_quit: false,
             autocomplete: AutocompleteState::new(),
+            value_memo: ValueMemo::new(),
             error_overlay_visible: false,
             history: HistoryState::new(),
             help: HelpPopupState::new(),

--- a/src/autocomplete.rs
+++ b/src/autocomplete.rs
@@ -8,6 +8,9 @@ pub mod json_navigator;
 pub mod path_parser;
 mod result_analyzer;
 mod scan_state;
+pub mod value_collector;
+pub mod value_insertion;
+pub mod value_trigger;
 mod variable_extractor;
 
 #[cfg(test)]

--- a/src/autocomplete/autocomplete_render.rs
+++ b/src/autocomplete/autocomplete_render.rs
@@ -86,6 +86,7 @@ pub fn render_popup(app: &App, frame: &mut Frame, input_area: Rect) -> Option<Re
                 SuggestionType::Operator => theme::autocomplete::TYPE_OPERATOR,
                 SuggestionType::Pattern => theme::autocomplete::TYPE_PATTERN,
                 SuggestionType::Variable => theme::autocomplete::TYPE_VARIABLE,
+                SuggestionType::Value => theme::autocomplete::TYPE_VALUE,
             };
 
             let type_label = get_type_label(suggestion);

--- a/src/autocomplete/autocomplete_state.rs
+++ b/src/autocomplete/autocomplete_state.rs
@@ -1,13 +1,45 @@
 use std::fmt;
+use std::sync::Arc;
 
 use crate::app::App;
+use crate::autocomplete::json_navigator::navigate_multi;
+use crate::autocomplete::path_parser::parse_path;
 use crate::autocomplete::update_suggestions;
+use crate::autocomplete::value_collector::collect_distinct_strings;
+use crate::autocomplete::value_trigger::{TriggerKind, ValueTrigger, classify};
 use crate::scroll::Scrollable;
 
 pub const MAX_VISIBLE_SUGGESTIONS: usize = 10;
 
+/// One-slot memo for value suggestions. Caches the most recent walk so that
+/// typing additional partial characters at the same trigger site filters the
+/// already-collected list instead of re-walking the JSON.
+#[derive(Debug, Default)]
+pub struct ValueMemo {
+    cache_key: Option<String>,
+    values: Arc<Vec<String>>,
+}
+
+impl ValueMemo {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn matches(&self, key: &str) -> bool {
+        self.cache_key.as_deref() == Some(key)
+    }
+
+    fn put(&mut self, key: String, values: Vec<String>) {
+        self.cache_key = Some(key);
+        self.values = Arc::new(values);
+    }
+
+    fn values(&self) -> Arc<Vec<String>> {
+        self.values.clone()
+    }
+}
+
 pub fn update_suggestions_from_app(app: &mut App) {
-    // Only update if query state is available
     let query_state = match &app.query {
         Some(q) => q,
         None => {
@@ -19,9 +51,25 @@ pub fn update_suggestions_from_app(app: &mut App) {
     let query = app.input.query().to_string();
     let cursor_char = app.input.textarea.cursor().1;
     let cursor_pos = crate::str_utils::char_pos_to_byte_pos(&query, cursor_char);
+    let original_json = query_state.executor.json_input_parsed();
+
+    if let Some(trigger) = classify(&query, cursor_pos) {
+        let all_string_values = query_state.executor.all_string_values();
+
+        let handled = update_value_suggestions(
+            &mut app.autocomplete,
+            &mut app.value_memo,
+            &trigger,
+            original_json.clone(),
+            all_string_values,
+        );
+        if handled {
+            return;
+        }
+    }
+
     let result_parsed = query_state.last_successful_result_parsed.clone();
     let result_type = query_state.base_type_for_suggestions.clone();
-    let original_json = query_state.executor.json_input_parsed();
     let all_field_names = query_state.executor.all_field_names();
 
     update_suggestions(
@@ -37,6 +85,134 @@ pub fn update_suggestions_from_app(app: &mut App) {
     );
 }
 
+/// Returns `true` when value autocomplete handled this keystroke. Returns
+/// `false` only for `has`/`in` calls whose LHS resolves to an object, where
+/// the caller should fall through to `ObjectKeyContext` dispatch.
+fn update_value_suggestions(
+    autocomplete: &mut AutocompleteState,
+    memo: &mut ValueMemo,
+    trigger: &ValueTrigger,
+    original_json: Option<Arc<serde_json::Value>>,
+    all_string_values: Arc<Vec<String>>,
+) -> bool {
+    let json = match original_json {
+        Some(j) => j,
+        None => {
+            autocomplete.hide();
+            return true;
+        }
+    };
+
+    if trigger.kind == TriggerKind::HasOrIn && lhs_resolves_to_object(&json, trigger) {
+        return false;
+    }
+
+    let cache_key = build_memo_key(trigger);
+    let collected = if memo.matches(&cache_key) {
+        memo.values()
+    } else {
+        let values = collect_for_trigger(trigger, &json, &all_string_values);
+        memo.put(cache_key, values);
+        memo.values()
+    };
+
+    let suggestions = build_value_suggestions(&collected, &trigger.partial);
+    autocomplete.update_suggestions(suggestions);
+    true
+}
+
+/// Memo key derived from the trigger's path. Two consecutive keystrokes at
+/// the same trigger site (e.g. `"a` → `"ac`) share a key, so the second
+/// re-uses the first walk.
+fn build_memo_key(trigger: &ValueTrigger) -> String {
+    match &trigger.lhs_path {
+        Some(p) => format!("path:{p}"),
+        None => "global".to_string(),
+    }
+}
+
+/// Walk `original_json` with the trigger's folded absolute path and collect
+/// distinct string values. If folding gave up (`lhs_path` is None) or the
+/// walk yields no strings, fall back to the executor's precomputed
+/// `all_string_values` (the global firehose).
+///
+/// Mid-query and end-of-query both use the same source — `original_json` —
+/// because the result_parsed cache is shape-unreliable for streaming queries
+/// (synthetic merges) and the folded path is rooted at the JSON root anyway.
+fn collect_for_trigger(
+    trigger: &ValueTrigger,
+    original_json: &serde_json::Value,
+    all_string_values: &[String],
+) -> Vec<String> {
+    if let Some(path) = trigger.lhs_path.as_deref() {
+        // The folded path is COMPLETE — every identifier is a final field
+        // name, including any trailing one that `parse_path` would otherwise
+        // treat as the user's in-progress input.
+        let parsed = parse_path(path);
+        let mut segments = parsed.segments;
+        if !parsed.partial.is_empty() {
+            segments.push(crate::autocomplete::path_parser::PathSegment::Field(
+                parsed.partial,
+            ));
+        }
+        if !segments.is_empty() {
+            let navigated = navigate_multi(original_json, &segments, VALUE_SAMPLE_SIZE);
+            if !navigated.is_empty() {
+                let strings = collect_distinct_strings(&navigated);
+                if !strings.is_empty() {
+                    return strings;
+                }
+            }
+        }
+    }
+    all_string_values.to_vec()
+}
+
+/// Sample size used when fanning out arrays during value collection. Higher
+/// than the field-name `DEFAULT_ARRAY_SAMPLE_SIZE = 10` so we don't miss
+/// values when distinct values cluster in non-uniform array slices.
+const VALUE_SAMPLE_SIZE: usize = 100;
+
+fn lhs_resolves_to_object(json: &serde_json::Value, trigger: &ValueTrigger) -> bool {
+    let path = match &trigger.lhs_path {
+        Some(p) => p,
+        None => return false,
+    };
+    let parsed = parse_path(path);
+    let mut segments = parsed.segments;
+    if !parsed.partial.is_empty() {
+        segments.push(crate::autocomplete::path_parser::PathSegment::Field(
+            parsed.partial,
+        ));
+    }
+    let values = navigate_multi(json, &segments, 1);
+    values
+        .into_iter()
+        .any(|v| matches!(v, serde_json::Value::Object(_)))
+}
+
+fn build_value_suggestions(values: &[String], partial: &str) -> Vec<Suggestion> {
+    let lower = partial.to_lowercase();
+    values
+        .iter()
+        .filter(|v| {
+            if lower.is_empty() {
+                true
+            } else {
+                v.to_lowercase().contains(&lower)
+            }
+        })
+        .take(MAX_VISIBLE_SUGGESTIONS * 4)
+        .map(|v| {
+            Suggestion::new_with_type(
+                v.clone(),
+                SuggestionType::Value,
+                Some(JsonFieldType::String),
+            )
+        })
+        .collect()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SuggestionType {
     Function,
@@ -44,6 +220,7 @@ pub enum SuggestionType {
     Operator,
     Pattern,
     Variable,
+    Value,
 }
 
 impl fmt::Display for SuggestionType {
@@ -54,6 +231,7 @@ impl fmt::Display for SuggestionType {
             SuggestionType::Operator => write!(f, "operator"),
             SuggestionType::Pattern => write!(f, "iterator"),
             SuggestionType::Variable => write!(f, "variable"),
+            SuggestionType::Value => write!(f, "value"),
         }
     }
 }

--- a/src/autocomplete/insertion.rs
+++ b/src/autocomplete/insertion.rs
@@ -6,7 +6,9 @@
 use tui_textarea::TextArea;
 
 use crate::app::App;
-use crate::autocomplete::autocomplete_state::Suggestion;
+use crate::autocomplete::autocomplete_state::{Suggestion, SuggestionType};
+use crate::autocomplete::value_insertion;
+use crate::autocomplete::value_trigger;
 use crate::autocomplete::{SuggestionContext, analyze_context};
 use crate::query::QueryState;
 
@@ -199,6 +201,19 @@ pub fn insert_suggestion(
     let cursor_char = textarea.cursor().1;
     let cursor_pos = crate::str_utils::char_pos_to_byte_pos(&query, cursor_char);
     let before_cursor = &query[..cursor_pos];
+
+    if suggestion.suggestion_type == SuggestionType::Value
+        && let Some(trigger) = value_trigger::classify(&query, cursor_pos)
+    {
+        value_insertion::apply_to_textarea(
+            textarea,
+            &query,
+            cursor_pos,
+            &trigger,
+            &suggestion.text,
+        );
+        return;
+    }
 
     let mut temp_tracker = crate::autocomplete::BraceTracker::new();
     temp_tracker.rebuild(before_cursor);

--- a/src/autocomplete/value_collector.rs
+++ b/src/autocomplete/value_collector.rs
@@ -1,0 +1,68 @@
+//! Distinct string-value collection from already-navigated JSON values.
+//!
+//! Takes the `Vec<&Value>` produced by `json_navigator::navigate_multi` and
+//! produces a deduplicated, frequency-sorted (alphabetical tiebreaker),
+//! capped list of distinct strings.
+//!
+//! Walks INTO terminal arrays so that paths landing on `["red", "blue"]` count
+//! each string element rather than the array as a whole.
+
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Per-path cap on distinct values returned. Bounds the suggestion list.
+pub const MAX_VALUES_PER_PATH: usize = 10_000;
+
+/// Collect distinct string values from a list of already-navigated JSON
+/// values. Each leaf string is counted; arrays at the leaf are walked into so
+/// `["a", "b", "a"]` produces `["a", "b"]` with `a` ranked first.
+///
+/// Output is sorted by descending frequency, alphabetical tiebreaker, capped
+/// at `MAX_VALUES_PER_PATH`.
+pub fn collect_distinct_strings(values: &[&Value]) -> Vec<String> {
+    let mut counts: HashMap<String, u32> = HashMap::new();
+    for value in values {
+        accumulate(value, &mut counts);
+        if counts.len() >= MAX_VALUES_PER_PATH {
+            break;
+        }
+    }
+    finalize(counts)
+}
+
+fn accumulate(value: &Value, counts: &mut HashMap<String, u32>) {
+    match value {
+        Value::String(s) => {
+            count_one(counts, s);
+        }
+        Value::Array(arr) => {
+            for element in arr {
+                if let Value::String(s) = element {
+                    count_one(counts, s);
+                    if counts.len() >= MAX_VALUES_PER_PATH {
+                        return;
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn count_one(counts: &mut HashMap<String, u32>, s: &str) {
+    if let Some(c) = counts.get_mut(s) {
+        *c += 1;
+    } else if counts.len() < MAX_VALUES_PER_PATH {
+        counts.insert(s.to_string(), 1);
+    }
+}
+
+fn finalize(counts: HashMap<String, u32>) -> Vec<String> {
+    let mut entries: Vec<(String, u32)> = counts.into_iter().collect();
+    entries.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    entries.into_iter().map(|(s, _)| s).collect()
+}
+
+#[cfg(test)]
+#[path = "value_collector_tests.rs"]
+mod value_collector_tests;

--- a/src/autocomplete/value_collector_tests.rs
+++ b/src/autocomplete/value_collector_tests.rs
@@ -1,0 +1,104 @@
+use super::*;
+use serde_json::{Value, json};
+
+fn collect(values: Vec<Value>) -> Vec<String> {
+    let refs: Vec<&Value> = values.iter().collect();
+    collect_distinct_strings(&refs)
+}
+
+#[test]
+fn empty_input_returns_empty() {
+    assert!(collect_distinct_strings(&[]).is_empty());
+}
+
+#[test]
+fn single_string_value() {
+    let v = json!("hello");
+    assert_eq!(collect_distinct_strings(&[&v]), vec!["hello"]);
+}
+
+#[test]
+fn ignores_non_string_scalars() {
+    let nums = vec![json!(1), json!(2.5), json!(true), json!(null)];
+    assert!(collect(nums).is_empty());
+}
+
+#[test]
+fn dedups_repeated_strings() {
+    let vs = vec![json!("a"), json!("a"), json!("b"), json!("a")];
+    // freq-sorted: "a"(3) first, "b"(1)
+    assert_eq!(collect(vs), vec!["a", "b"]);
+}
+
+#[test]
+fn frequency_descending_with_alpha_tiebreak() {
+    let vs = vec![
+        json!("zebra"),
+        json!("apple"),
+        json!("zebra"),
+        json!("mango"),
+        json!("apple"),
+    ];
+    // "apple" 2, "zebra" 2, "mango" 1 → tiebreak alpha: apple, zebra, mango
+    assert_eq!(collect(vs), vec!["apple", "zebra", "mango"]);
+}
+
+#[test]
+fn walks_into_terminal_array_of_strings() {
+    // Path `.tags` lands on ["red", "blue", "red"] — collector walks into it.
+    let arr = json!(["red", "blue", "red"]);
+    assert_eq!(collect_distinct_strings(&[&arr]), vec!["red", "blue"]);
+}
+
+#[test]
+fn ignores_arrays_with_non_strings() {
+    let arr = json!([1, 2, "kept", 3]);
+    assert_eq!(collect_distinct_strings(&[&arr]), vec!["kept"]);
+}
+
+#[test]
+fn objects_at_leaf_are_skipped() {
+    // navigate_multi can return objects; we don't suggest object representations.
+    let obj = json!({ "k": "v" });
+    assert!(collect_distinct_strings(&[&obj]).is_empty());
+}
+
+#[test]
+fn utf8_strings_preserved() {
+    let vs = vec![json!("üñ"), json!("café"), json!("üñ")];
+    let r = collect(vs);
+    assert_eq!(r, vec!["üñ", "café"]);
+}
+
+#[test]
+fn caps_at_max_values_per_path() {
+    let mut vs = Vec::with_capacity(MAX_VALUES_PER_PATH + 50);
+    for i in 0..(MAX_VALUES_PER_PATH + 50) {
+        vs.push(Value::String(format!("v{}", i)));
+    }
+    let r = collect(vs);
+    assert_eq!(r.len(), MAX_VALUES_PER_PATH);
+}
+
+#[test]
+fn cap_applies_to_terminal_array_walk() {
+    // A single navigated value that IS an array of >cap distinct strings.
+    let big: Vec<Value> = (0..MAX_VALUES_PER_PATH + 50)
+        .map(|i| Value::String(format!("v{}", i)))
+        .collect();
+    let arr = Value::Array(big);
+    let r = collect_distinct_strings(&[&arr]);
+    assert_eq!(r.len(), MAX_VALUES_PER_PATH);
+}
+
+#[test]
+fn mixed_string_and_terminal_array_values() {
+    // Simulates navigating a path that returns both bare strings and arrays.
+    let s1 = json!("alpha");
+    let s2 = json!("beta");
+    let arr = json!(["alpha", "gamma"]);
+    let r = collect_distinct_strings(&[&s1, &s2, &arr]);
+    // alpha appears twice (once direct, once in arr), beta once, gamma once.
+    // Alphabetical tiebreak between beta and gamma.
+    assert_eq!(r, vec!["alpha", "beta", "gamma"]);
+}

--- a/src/autocomplete/value_insertion.rs
+++ b/src/autocomplete/value_insertion.rs
@@ -1,0 +1,94 @@
+//! Insertion of selected string values into the query.
+//!
+//! Replaces the partial inside the active `"..."` with the selected value
+//! (jq-escaped) and ensures exactly one closing `"`. Cursor lands on the byte
+//! immediately after the closing `"`.
+
+use tui_textarea::TextArea;
+
+use super::value_trigger::ValueTrigger;
+use crate::str_utils::byte_pos_to_char_pos;
+
+/// Build the new query buffer after inserting a value.
+/// Returns `(new_query, cursor_byte_after_close)`.
+pub(crate) fn build_inserted(
+    query: &str,
+    cursor_byte: usize,
+    trigger: &ValueTrigger,
+    value: &str,
+) -> (String, usize) {
+    let _ = cursor_byte;
+    let escaped = escape_jq_string(value);
+
+    let body_start = trigger.quote_open_byte + 1;
+    let prefix = &query[..body_start];
+
+    // Suffix begins after the close quote of the active string. If a close
+    // quote exists anywhere from body_start onward, skip past it; otherwise
+    // the string runs to end-of-query and there is no suffix.
+    let suffix_start = match find_close_quote(query, body_start) {
+        Some(close) => close + 1,
+        None => query.len(),
+    };
+
+    let suffix = &query[suffix_start..];
+    let mut new_query = String::with_capacity(prefix.len() + escaped.len() + 1 + suffix.len());
+    new_query.push_str(prefix);
+    new_query.push_str(&escaped);
+    new_query.push('"');
+    let cursor_after = new_query.len();
+    new_query.push_str(suffix);
+    (new_query, cursor_after)
+}
+
+pub(crate) fn apply_to_textarea(
+    textarea: &mut TextArea<'_>,
+    query: &str,
+    cursor_byte: usize,
+    trigger: &ValueTrigger,
+    value: &str,
+) {
+    let (new_query, cursor_after) = build_inserted(query, cursor_byte, trigger, value);
+    let cursor_char = byte_pos_to_char_pos(&new_query, cursor_after);
+
+    textarea.delete_line_by_head();
+    textarea.delete_line_by_end();
+    textarea.insert_str(&new_query);
+    super::insertion::move_cursor_to_column(textarea, cursor_char);
+}
+
+fn escape_jq_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+/// Locate the next unescaped `"` from `from`. Skips over `\\"` correctly.
+fn find_close_quote(query: &str, from: usize) -> Option<usize> {
+    let bytes = query.as_bytes();
+    let mut i = from;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => i += 2,
+            b'"' => return Some(i),
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+#[path = "value_insertion_tests.rs"]
+mod value_insertion_tests;

--- a/src/autocomplete/value_insertion_tests.rs
+++ b/src/autocomplete/value_insertion_tests.rs
@@ -1,0 +1,204 @@
+use super::*;
+use crate::autocomplete::value_trigger::{TriggerKind, ValueTrigger};
+
+fn trigger_at_quote(query: &str) -> ValueTrigger {
+    let qb = query.rfind('"').expect("quote present");
+    let partial = query[qb + 1..].to_string();
+    ValueTrigger {
+        kind: TriggerKind::Eq,
+        lhs_path: Some(".x".to_string()),
+        partial,
+        quote_open_byte: qb,
+    }
+}
+
+#[test]
+fn appends_close_quote_when_missing() {
+    let q = "select(.x == \"ab";
+    let trig = trigger_at_quote(q);
+    let (new_q, cursor) = build_inserted(q, q.len(), &trig, "abc");
+    assert_eq!(new_q, "select(.x == \"abc\"");
+    assert_eq!(cursor, new_q.len());
+}
+
+#[test]
+fn replaces_existing_close_quote() {
+    let q = "select(.x == \"ab\")";
+    let cursor = q.find("ab").unwrap() + 2;
+    let trig = ValueTrigger {
+        kind: TriggerKind::Eq,
+        lhs_path: Some(".x".to_string()),
+        partial: "ab".to_string(),
+        quote_open_byte: q.find('"').unwrap(),
+    };
+    let (new_q, cursor_after) = build_inserted(q, cursor, &trig, "abc");
+    assert_eq!(new_q, "select(.x == \"abc\")");
+    let close_quote_byte = new_q.rfind('"').unwrap();
+    assert_eq!(cursor_after, close_quote_byte + 1);
+}
+
+#[test]
+fn escapes_embedded_double_quote() {
+    let q = "select(.x == \"";
+    let trig = trigger_at_quote(q);
+    let (new_q, _) = build_inserted(q, q.len(), &trig, "say \"hi\"");
+    assert_eq!(new_q, "select(.x == \"say \\\"hi\\\"\"");
+}
+
+#[test]
+fn escapes_backslash() {
+    let q = "select(.x == \"";
+    let trig = trigger_at_quote(q);
+    let (new_q, _) = build_inserted(q, q.len(), &trig, r"a\b");
+    assert_eq!(new_q, "select(.x == \"a\\\\b\"");
+}
+
+#[test]
+fn escapes_control_chars() {
+    let q = "select(.x == \"";
+    let trig = trigger_at_quote(q);
+    let (new_q, _) = build_inserted(q, q.len(), &trig, "line1\nline2");
+    assert_eq!(new_q, "select(.x == \"line1\\nline2\"");
+}
+
+#[test]
+fn preserves_utf8_in_value() {
+    let q = "select(.name == \"";
+    let trig = trigger_at_quote(q);
+    let (new_q, _) = build_inserted(q, q.len(), &trig, "üñ");
+    assert_eq!(new_q, "select(.name == \"üñ\"");
+}
+
+#[test]
+fn preserves_text_after_cursor() {
+    let q = "select(.x == \"\") | length";
+    // cursor is between "" — the empty quoted string
+    let cursor = q.find("\"\"").unwrap() + 1;
+    let trig = ValueTrigger {
+        kind: TriggerKind::Eq,
+        lhs_path: Some(".x".to_string()),
+        partial: String::new(),
+        quote_open_byte: q.find('"').unwrap(),
+    };
+    let (new_q, _) = build_inserted(q, cursor, &trig, "yes");
+    assert_eq!(new_q, "select(.x == \"yes\") | length");
+}
+
+#[test]
+fn cursor_lands_after_close_quote() {
+    let q = "select(.x == \"";
+    let trig = trigger_at_quote(q);
+    let (new_q, cursor) = build_inserted(q, q.len(), &trig, "abc");
+    assert_eq!(&new_q[cursor.saturating_sub(1)..cursor], "\"");
+}
+
+#[test]
+fn empty_value_just_closes_quote() {
+    let q = "select(.x == \"";
+    let trig = trigger_at_quote(q);
+    let (new_q, _) = build_inserted(q, q.len(), &trig, "");
+    assert_eq!(new_q, "select(.x == \"\"");
+}
+
+#[test]
+fn does_not_double_escape() {
+    // Roundtrip: the escaped output should never contain unescaped \" or \\.
+    let q = "x == \"";
+    let trig = trigger_at_quote(q);
+    let (new_q, _) = build_inserted(q, q.len(), &trig, r#"a"b\c"#);
+    assert!(new_q.contains(r#"\"b"#));
+    assert!(new_q.contains(r#"\\c"#));
+}
+
+#[test]
+fn cursor_at_close_quote_with_existing_string() {
+    // User typed select(.x == "ab"|) | length where | is cursor — popup shows.
+    // Selecting "abc" should produce select(.x == "abc") | length
+    let q = "select(.x == \"ab\") | length";
+    let cursor = q.find("ab\"").unwrap() + 2;
+    let trig = ValueTrigger {
+        kind: TriggerKind::Eq,
+        lhs_path: Some(".x".to_string()),
+        partial: "ab".to_string(),
+        quote_open_byte: q.find('"').unwrap(),
+    };
+    let (new_q, _) = build_inserted(q, cursor, &trig, "abc");
+    assert_eq!(new_q, "select(.x == \"abc\") | length");
+}
+
+#[test]
+fn no_double_quote_when_user_already_typed_close() {
+    let q = "select(.x == \"\") | length";
+    let cursor = q.find("\"\"").unwrap() + 1;
+    let trig = ValueTrigger {
+        kind: TriggerKind::Eq,
+        lhs_path: Some(".x".to_string()),
+        partial: String::new(),
+        quote_open_byte: q.find('"').unwrap(),
+    };
+    let (new_q, _) = build_inserted(q, cursor, &trig, "yes");
+    let count = new_q.matches('"').count();
+    assert_eq!(count, 2, "expected exactly 2 quote chars in {new_q:?}");
+}
+
+#[test]
+fn cursor_inside_partial_with_existing_close_quote() {
+    // Cursor sits between 'a' and 'b' in "ab" — partial = "a", but the
+    // string already has a close quote later. Insertion must NOT leave a
+    // dangling 'b' between value and close quote.
+    let q = "select(.x == \"ab\")";
+    let cursor = q.find("ab").unwrap() + 1;
+    let trig = ValueTrigger {
+        kind: TriggerKind::Eq,
+        lhs_path: Some(".x".to_string()),
+        partial: "a".to_string(),
+        quote_open_byte: q.find('"').unwrap(),
+    };
+    let (new_q, _) = build_inserted(q, cursor, &trig, "abc");
+    assert_eq!(new_q, "select(.x == \"abc\")");
+    let quote_count = new_q.matches('"').count();
+    assert_eq!(quote_count, 2, "expected exactly 2 quotes in {new_q:?}");
+}
+
+#[test]
+fn cursor_anywhere_in_string_body_replaces_whole_body() {
+    // The new behavior: regardless of cursor position inside the string,
+    // the whole body up to the close quote is replaced by the value.
+    let q = "select(.x == \"abcdef\")";
+    let trig = ValueTrigger {
+        kind: TriggerKind::Eq,
+        lhs_path: Some(".x".to_string()),
+        partial: "abc".to_string(),
+        quote_open_byte: q.find('"').unwrap(),
+    };
+    // Try cursors at multiple points inside "abcdef"
+    for pos in 0..="abcdef".len() {
+        let cursor = q.find('"').unwrap() + 1 + pos;
+        let (new_q, _) = build_inserted(q, cursor, &trig, "X");
+        assert_eq!(new_q, "select(.x == \"X\")");
+    }
+}
+
+#[test]
+fn jq_round_trip_property() {
+    // For a small set of representative values, confirm that the inserted
+    // string parses back to the original via a manual unescape that matches
+    // jq's rules. (Avoids spawning jq for unit tests; the manual unescape is
+    // narrow but covers the escapes we emit.)
+    let cases = [
+        "plain",
+        "with space",
+        "üñ",
+        r#"a"b"#,
+        r"a\b",
+        "tab\there",
+        "newline\nhere",
+        "",
+    ];
+    for value in cases {
+        let escaped = escape_jq_string(value);
+        let parsed: String = serde_json::from_str(&format!("\"{}\"", escaped))
+            .expect("escaped string is valid JSON");
+        assert_eq!(parsed, value, "round trip failed for {value:?}");
+    }
+}

--- a/src/autocomplete/value_trigger.rs
+++ b/src/autocomplete/value_trigger.rs
@@ -1,0 +1,534 @@
+//! Trigger classifier for string-value autocomplete.
+//!
+//! Decides whether the cursor sits inside an unclosed `"..."` literal at a
+//! value-comparison position. When it does, returns enough context to look up
+//! candidate values from the loaded JSON. Pure function operating on byte
+//! offsets so callers can feed it `cursor_pos` directly from the editor.
+//!
+//! Returns `None` for regex argument functions (`test`, `match`, `scan`,
+//! `splits`, `sub`, `gsub`), strings containing `\(` interpolation, and
+//! strings already terminated before the cursor.
+//!
+//! Path folding: when a trigger fires inside `select(...)` or after a pipe
+//! `<expr> | <trigger>`, the classifier folds the surrounding context into a
+//! single absolute path rooted at the JSON root. So
+//! `.users[] | select(.role == "` produces `lhs_path = .users[].role` rather
+//! than just `.role`. Folding recognizes `select` (identity on input) and
+//! `map` (iterates input). Anything else (`reduce`, `foreach`, user-defined
+//! functions, `sort_by`, etc.) causes folding to give up and return `None`,
+//! and the dispatcher falls back to the global string list.
+
+use super::scan_state::ScanState;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TriggerKind {
+    Eq,
+    Neq,
+    Contains,
+    StartsWith,
+    EndsWith,
+    Inside,
+    In,
+    HasOrIn,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ValueTrigger {
+    pub kind: TriggerKind,
+    pub lhs_path: Option<String>,
+    pub partial: String,
+    pub quote_open_byte: usize,
+}
+
+const REGEX_FUNCTIONS: &[&str] = &["test", "match", "scan", "splits", "sub", "gsub"];
+
+const STRING_PREDICATES: &[(&str, TriggerKind)] = &[
+    ("contains", TriggerKind::Contains),
+    ("startswith", TriggerKind::StartsWith),
+    ("endswith", TriggerKind::EndsWith),
+    ("inside", TriggerKind::Inside),
+];
+
+/// Wrappers we treat as identity-on-input when folding paths. These functions
+/// either pass their input through (`select`) or filter without transforming
+/// (`first`, `last`, `values`, etc.). For our purposes they don't change the
+/// path that should be walked from the JSON root.
+const IDENTITY_WRAPPERS: &[&str] = &[
+    "select",
+    "first",
+    "last",
+    "limit",
+    "values",
+    "nulls",
+    "booleans",
+    "numbers",
+    "strings",
+    "arrays",
+    "objects",
+    "iterables",
+    "scalars",
+    "any",
+    "all",
+];
+
+/// Wrappers that iterate their input (each element of an input array becomes
+/// the `.` for the body). When folding through one, we prepend `[]` because
+/// the body operates on each element.
+const ITERATING_WRAPPERS: &[&str] = &["map", "map_values"];
+
+pub(crate) fn classify(query: &str, cursor_byte: usize) -> Option<ValueTrigger> {
+    let cursor = clamp_to_char_boundary(query, cursor_byte);
+    let prefix = &query[..cursor];
+
+    let (quote_open_byte, partial_text) = locate_active_string(prefix)?;
+    if partial_contains_interpolation(&partial_text) {
+        return None;
+    }
+
+    let before_quote = prefix[..quote_open_byte].trim_end_matches(is_h_ws);
+
+    if let Some(kind) = match_eq_neq(before_quote) {
+        let op_len = 2;
+        let before_op = &before_quote[..before_quote.len() - op_len];
+        let before_op_trimmed = before_op.trim_end_matches(is_h_ws);
+        let inner_lhs = extract_trailing_path(before_op_trimmed);
+        let lhs_start = match &inner_lhs {
+            Some(p) => before_op_trimmed.len().saturating_sub(p.len()),
+            None => before_op_trimmed.len(),
+        };
+        let lhs_path = fold_to_absolute_path(prefix, lhs_start, inner_lhs);
+        return Some(ValueTrigger {
+            kind,
+            lhs_path,
+            partial: partial_text,
+            quote_open_byte,
+        });
+    }
+
+    let call = enclosing_function_call(prefix, quote_open_byte)?;
+
+    if REGEX_FUNCTIONS.iter().any(|n| *n == call.name) {
+        return None;
+    }
+
+    if let Some((_, kind)) = STRING_PREDICATES.iter().find(|(n, _)| *n == call.name) {
+        let (inner_lhs, lhs_start) = extract_pre_call_path(prefix, call.name_start);
+        let lhs_path = fold_to_absolute_path(prefix, lhs_start, inner_lhs);
+        return Some(ValueTrigger {
+            kind: *kind,
+            lhs_path,
+            partial: partial_text,
+            quote_open_byte,
+        });
+    }
+
+    if call.name == "IN" {
+        let inner_lhs = extract_in_lhs_path(&call.arg_text_until_quote);
+        // For IN, fold from the position immediately before the call name —
+        // that's where any `<path> | IN(...)` would be.
+        let lhs_path = fold_to_absolute_path(prefix, call.name_start, inner_lhs);
+        return Some(ValueTrigger {
+            kind: TriggerKind::In,
+            lhs_path,
+            partial: partial_text,
+            quote_open_byte,
+        });
+    }
+
+    if call.name == "has" || call.name == "in" {
+        let (inner_lhs, lhs_start) = extract_pre_call_path(prefix, call.name_start);
+        let lhs_path = fold_to_absolute_path(prefix, lhs_start, inner_lhs);
+        return Some(ValueTrigger {
+            kind: TriggerKind::HasOrIn,
+            lhs_path,
+            partial: partial_text,
+            quote_open_byte,
+        });
+    }
+
+    None
+}
+
+/// Fold the inner relative path into an absolute path rooted at the JSON root
+/// by walking outward through enclosing `select`/`map`/`<path> | <here>`
+/// constructs. Returns `None` if the surrounding context can't be folded
+/// safely (reduce, foreach, user-defined functions, etc.).
+fn fold_to_absolute_path(prefix: &str, start: usize, inner: Option<String>) -> Option<String> {
+    let mut accumulated = inner.unwrap_or_default();
+    let mut cursor = start;
+    let mut hops = 0;
+
+    loop {
+        if hops > 32 {
+            return None;
+        }
+        hops += 1;
+
+        match find_enclosing_construct(prefix, cursor) {
+            EnclosingConstruct::None => break,
+            EnclosingConstruct::Pipe { left_end } => {
+                let left_path = extract_path_chain_ending_at(prefix, left_end)?;
+                let left_path_start = left_end
+                    .saturating_sub(skip_ws_back(prefix, left_end))
+                    .saturating_sub(left_path.len());
+                accumulated = concat_paths(&left_path, &accumulated);
+                cursor = left_path_start;
+            }
+            EnclosingConstruct::IdentityWrapper { call_start } => {
+                cursor = call_start;
+            }
+            EnclosingConstruct::IteratingWrapper { call_start } => {
+                accumulated = concat_paths("[]", &accumulated);
+                cursor = call_start;
+            }
+            EnclosingConstruct::Unknown => return None,
+        }
+    }
+
+    if accumulated.is_empty() {
+        return None;
+    }
+    canonicalize_absolute(&accumulated)
+}
+
+/// Concatenate two path segments. Both may or may not start with `.` or `[`.
+fn concat_paths(left: &str, right: &str) -> String {
+    if right.is_empty() {
+        return left.to_string();
+    }
+    if left.is_empty() {
+        return right.to_string();
+    }
+    // Avoid `.` between `[]` and the next segment when the next starts with `.`.
+    // Just concatenate; `parse_path` handles either form.
+    format!("{}{}", left, right)
+}
+
+fn canonicalize_absolute(path: &str) -> Option<String> {
+    if path.starts_with('.') {
+        Some(path.to_string())
+    } else {
+        Some(format!(".{}", path))
+    }
+}
+
+#[derive(Debug)]
+enum EnclosingConstruct {
+    None,
+    /// `<left_path> | <here>` — `left_end` is the byte position of the `|`.
+    Pipe {
+        left_end: usize,
+    },
+    /// `select(<here>)` and other identity-on-input wrappers — `call_start`
+    /// is the byte position of the first character of the call name.
+    IdentityWrapper {
+        call_start: usize,
+    },
+    /// `map(<here>)` and other iterating wrappers — `call_start` is the byte
+    /// position of the first character of the call name.
+    IteratingWrapper {
+        call_start: usize,
+    },
+    /// Some other enclosing construct we can't safely fold across (reduce,
+    /// foreach, user-defined functions, sort_by, etc.).
+    Unknown,
+}
+
+fn find_enclosing_construct(prefix: &str, cursor: usize) -> EnclosingConstruct {
+    let bytes = prefix.as_bytes();
+    let cursor = cursor.min(bytes.len());
+
+    // Walk back through whitespace.
+    let mut i = cursor;
+    while i > 0 && is_h_ws(bytes[i - 1] as char) {
+        i -= 1;
+    }
+    if i == 0 {
+        return EnclosingConstruct::None;
+    }
+
+    // If we're directly preceded by `|`, that's a pipe boundary. Exclude `|=`
+    // (update assignment).
+    if bytes[i - 1] == b'|' {
+        if i >= 2 && bytes[i - 2] == b'|' {
+            return EnclosingConstruct::Unknown;
+        }
+        return EnclosingConstruct::Pipe { left_end: i - 1 };
+    }
+
+    // Otherwise look for an enclosing unclosed paren whose call name we
+    // recognize. The paren must be the *immediate* enclosing context — i.e.
+    // there must be only whitespace between `(` and the cursor.
+    if bytes[i - 1] != b'(' {
+        return EnclosingConstruct::None;
+    }
+    let between = &prefix[..cursor];
+    let paren_pos = match find_innermost_unclosed_paren(between) {
+        Some(p) => p,
+        None => return EnclosingConstruct::None,
+    };
+    if paren_pos != i - 1 {
+        return EnclosingConstruct::None;
+    }
+
+    let before_paren = &between[..paren_pos];
+    let trimmed = before_paren.trim_end_matches(is_h_ws);
+    let name_end = trimmed.len();
+    let name_start = identifier_start(trimmed, name_end);
+    if name_start == name_end {
+        return EnclosingConstruct::Unknown;
+    }
+    let name = &trimmed[name_start..name_end];
+
+    if IDENTITY_WRAPPERS.contains(&name) {
+        return EnclosingConstruct::IdentityWrapper {
+            call_start: name_start,
+        };
+    }
+    if ITERATING_WRAPPERS.contains(&name) {
+        return EnclosingConstruct::IteratingWrapper {
+            call_start: name_start,
+        };
+    }
+    EnclosingConstruct::Unknown
+}
+
+fn extract_path_chain_ending_at(prefix: &str, end: usize) -> Option<String> {
+    let bytes = prefix.as_bytes();
+    let mut i = end;
+    while i > 0 && is_h_ws(bytes[i - 1] as char) {
+        i -= 1;
+    }
+    let chain_end = i;
+    while i > 0 {
+        let b = bytes[i - 1];
+        if is_path_byte(b) {
+            i -= 1;
+        } else {
+            break;
+        }
+    }
+    let candidate = &prefix[i..chain_end];
+    let trimmed = candidate.trim();
+    if trimmed.is_empty() || !trimmed.starts_with('.') {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+fn skip_ws_back(prefix: &str, pos: usize) -> usize {
+    let bytes = prefix.as_bytes();
+    let pos = pos.min(bytes.len());
+    let mut i = pos;
+    while i > 0 && is_h_ws(bytes[i - 1] as char) {
+        i -= 1;
+    }
+    pos - i
+}
+
+fn clamp_to_char_boundary(s: &str, byte: usize) -> usize {
+    let mut clamped = byte.min(s.len());
+    while clamped > 0 && !s.is_char_boundary(clamped) {
+        clamped -= 1;
+    }
+    clamped
+}
+
+fn is_h_ws(c: char) -> bool {
+    c == ' ' || c == '\t'
+}
+
+fn locate_active_string(prefix: &str) -> Option<(usize, String)> {
+    let mut state = ScanState::default();
+    let mut quote_byte: Option<usize> = None;
+
+    for (idx, ch) in prefix.char_indices() {
+        let was_in = state.is_in_string();
+        let next = state.advance(ch);
+        let now_in = next.is_in_string();
+        if !was_in && now_in {
+            quote_byte = Some(idx);
+        } else if was_in && !now_in {
+            quote_byte = None;
+        }
+        state = next;
+    }
+
+    if !state.is_in_string() {
+        return None;
+    }
+
+    let qb = quote_byte?;
+    let partial = prefix[qb + 1..].to_string();
+    Some((qb, partial))
+}
+
+fn partial_contains_interpolation(partial: &str) -> bool {
+    let bytes = partial.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' {
+            if i + 1 < bytes.len() && bytes[i + 1] == b'(' {
+                return true;
+            }
+            i += 2;
+            continue;
+        }
+        i += 1;
+    }
+    false
+}
+
+fn match_eq_neq(before_quote: &str) -> Option<TriggerKind> {
+    if before_quote.ends_with("==") {
+        Some(TriggerKind::Eq)
+    } else if before_quote.ends_with("!=") {
+        Some(TriggerKind::Neq)
+    } else {
+        None
+    }
+}
+
+#[derive(Debug)]
+struct EnclosingCall {
+    name: String,
+    name_start: usize,
+    arg_text_until_quote: String,
+}
+
+fn enclosing_function_call(prefix: &str, quote_open_byte: usize) -> Option<EnclosingCall> {
+    let between = &prefix[..quote_open_byte];
+    let paren_pos = find_innermost_unclosed_paren(between)?;
+
+    let after_paren = &between[paren_pos + 1..];
+    let arg_text_until_quote = after_paren.trim().to_string();
+
+    let before_paren = &between[..paren_pos];
+    let trimmed = before_paren.trim_end_matches(is_h_ws);
+    let name_end = trimmed.len();
+    let name_start = identifier_start(trimmed, name_end);
+    if name_start == name_end {
+        return None;
+    }
+    let name = trimmed[name_start..name_end].to_string();
+
+    Some(EnclosingCall {
+        name,
+        name_start,
+        arg_text_until_quote,
+    })
+}
+
+fn find_innermost_unclosed_paren(text: &str) -> Option<usize> {
+    let mut state = ScanState::default();
+    let mut stack: Vec<usize> = Vec::new();
+    for (idx, ch) in text.char_indices() {
+        let was_in = state.is_in_string();
+        let next = state.advance(ch);
+        if !was_in && !next.is_in_string() {
+            match ch {
+                '(' => stack.push(idx),
+                ')' => {
+                    stack.pop();
+                }
+                _ => {}
+            }
+        }
+        state = next;
+    }
+    stack.last().copied()
+}
+
+fn identifier_start(text: &str, end: usize) -> usize {
+    let bytes = text.as_bytes();
+    let mut i = end;
+    while i > 0 && is_ident_byte(bytes[i - 1]) {
+        i -= 1;
+    }
+    i
+}
+
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// Returns `(inner_lhs, position_where_the_inner_path_starts_in_prefix)`.
+/// When there's no `<path> |` immediately before the call, returns
+/// `(None, name_start)` so callers can still fold from the call's own
+/// position.
+fn extract_pre_call_path(prefix: &str, name_start: usize) -> (Option<String>, usize) {
+    let bytes = prefix.as_bytes();
+    let mut i = name_start;
+    while i > 0 && is_h_ws(bytes[i - 1] as char) {
+        i -= 1;
+    }
+    if i == 0 || bytes[i - 1] != b'|' {
+        return (None, name_start);
+    }
+    let pipe_pos = i - 1;
+    let mut j = pipe_pos;
+    while j > 0 && is_h_ws(bytes[j - 1] as char) {
+        j -= 1;
+    }
+    let chain_end = j;
+    while j > 0 {
+        let b = bytes[j - 1];
+        if is_path_byte(b) {
+            j -= 1;
+        } else {
+            break;
+        }
+    }
+    let candidate = &prefix[j..chain_end];
+    if candidate.starts_with('.') {
+        (Some(candidate.to_string()), j)
+    } else {
+        (None, name_start)
+    }
+}
+
+fn extract_in_lhs_path(arg_text: &str) -> Option<String> {
+    let semi = arg_text.find(';')?;
+    let lhs = arg_text[..semi].trim();
+    if lhs.is_empty() {
+        return None;
+    }
+    canonicalize_path(lhs)
+}
+
+/// Walks backwards from the end of `text`, collecting only path-relevant
+/// characters (`.`, identifier chars, `?`, `[`, `]`, digits, `-`). Returns the
+/// resulting path if it begins with `.`.
+fn extract_trailing_path(text: &str) -> Option<String> {
+    if text.is_empty() {
+        return None;
+    }
+    let bytes = text.as_bytes();
+    let mut i = bytes.len();
+    while i > 0 {
+        let b = bytes[i - 1];
+        if is_path_byte(b) {
+            i -= 1;
+        } else {
+            break;
+        }
+    }
+    let candidate = &text[i..];
+    canonicalize_path(candidate)
+}
+
+fn is_path_byte(b: u8) -> bool {
+    b == b'.' || b == b'?' || b == b'[' || b == b']' || b == b'-' || is_ident_byte(b)
+}
+
+fn canonicalize_path(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || !trimmed.starts_with('.') {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+#[cfg(test)]
+#[path = "value_trigger_tests.rs"]
+mod value_trigger_tests;

--- a/src/autocomplete/value_trigger_tests.rs
+++ b/src/autocomplete/value_trigger_tests.rs
@@ -1,0 +1,413 @@
+use super::*;
+
+fn classify_at_end(query: &str) -> Option<ValueTrigger> {
+    classify(query, query.len())
+}
+
+#[test]
+fn returns_none_outside_string() {
+    assert!(classify_at_end("select(.x == ").is_none());
+    assert!(classify_at_end(".items").is_none());
+    assert!(classify_at_end("").is_none());
+}
+
+#[test]
+fn returns_none_when_string_already_closed() {
+    assert!(classify_at_end("select(.x == \"abc\")").is_none());
+    assert!(classify_at_end("\"hello\"").is_none());
+}
+
+#[test]
+fn returns_none_for_regex_functions() {
+    assert!(classify_at_end("test(\"").is_none());
+    assert!(classify_at_end("match(\"foo").is_none());
+    assert!(classify_at_end("scan(\"x").is_none());
+    assert!(classify_at_end("splits(\"a").is_none());
+    assert!(classify_at_end("sub(\"a").is_none());
+    assert!(classify_at_end("gsub(\"x").is_none());
+}
+
+#[test]
+fn returns_none_inside_string_interpolation() {
+    let q = "\"prefix\\(.x)";
+    assert!(classify(q, q.len()).is_none());
+}
+
+#[test]
+fn detects_eq_with_path() {
+    let t = classify_at_end("select(.status == \"ac").expect("trigger");
+    assert_eq!(t.kind, TriggerKind::Eq);
+    assert_eq!(t.lhs_path.as_deref(), Some(".status"));
+    assert_eq!(t.partial, "ac");
+}
+
+#[test]
+fn detects_neq_with_path() {
+    let t = classify_at_end(".user.role != \"ad").expect("trigger");
+    assert_eq!(t.kind, TriggerKind::Neq);
+    assert_eq!(t.lhs_path.as_deref(), Some(".user.role"));
+    assert_eq!(t.partial, "ad");
+}
+
+#[test]
+fn detects_eq_without_lhs_path() {
+    let t = classify_at_end("== \"foo").expect("trigger");
+    assert_eq!(t.kind, TriggerKind::Eq);
+    assert!(t.lhs_path.is_none());
+    assert_eq!(t.partial, "foo");
+}
+
+#[test]
+fn detects_eq_with_no_space_before_op() {
+    let t = classify_at_end(".status==\"ac").expect("trigger");
+    assert_eq!(t.kind, TriggerKind::Eq);
+    assert_eq!(t.lhs_path.as_deref(), Some(".status"));
+    assert_eq!(t.partial, "ac");
+}
+
+#[test]
+fn detects_contains_no_lhs() {
+    let t = classify_at_end("contains(\"ab").expect("trigger");
+    assert_eq!(t.kind, TriggerKind::Contains);
+    assert!(t.lhs_path.is_none());
+    assert_eq!(t.partial, "ab");
+}
+
+#[test]
+fn detects_contains_with_pre_call_path() {
+    let t = classify_at_end(".name | contains(\"x").expect("trigger");
+    assert_eq!(t.kind, TriggerKind::Contains);
+    assert_eq!(t.lhs_path.as_deref(), Some(".name"));
+}
+
+#[test]
+fn detects_startswith() {
+    let t = classify_at_end("startswith(\"pre").expect("trigger");
+    assert_eq!(t.kind, TriggerKind::StartsWith);
+    assert_eq!(t.partial, "pre");
+}
+
+#[test]
+fn detects_endswith() {
+    let t = classify_at_end("endswith(\".log").expect("trigger");
+    assert_eq!(t.kind, TriggerKind::EndsWith);
+    assert_eq!(t.partial, ".log");
+}
+
+#[test]
+fn detects_inside() {
+    let t = classify_at_end("inside(\"abc").expect("trigger");
+    assert_eq!(t.kind, TriggerKind::Inside);
+}
+
+#[test]
+fn detects_in_with_lhs_path() {
+    let t = classify_at_end("IN(.role; \"ad").expect("trigger");
+    assert_eq!(t.kind, TriggerKind::In);
+    assert_eq!(t.lhs_path.as_deref(), Some(".role"));
+    assert_eq!(t.partial, "ad");
+}
+
+#[test]
+fn detects_in_without_lhs_path() {
+    let t = classify_at_end("IN(\"ad").expect("trigger");
+    assert_eq!(t.kind, TriggerKind::In);
+    assert!(t.lhs_path.is_none());
+}
+
+#[test]
+fn detects_has_or_in() {
+    let t = classify_at_end("has(\"k").expect("trigger");
+    assert_eq!(t.kind, TriggerKind::HasOrIn);
+    let t = classify_at_end(".x | in(\"k").expect("trigger");
+    assert_eq!(t.kind, TriggerKind::HasOrIn);
+}
+
+#[test]
+fn handles_nested_call() {
+    // `map(select(.role == "ad` — fold prepends `[]` for `map` and
+    // identity-walks `select`, yielding `[].role`. Without an LHS to the
+    // map, the absolute path can't be rooted — but the iterator step
+    // is still meaningful as a top-level array iteration.
+    let t = classify_at_end("map(select(.role == \"ad").expect("trigger");
+    assert_eq!(t.kind, TriggerKind::Eq);
+    assert_eq!(t.lhs_path.as_deref(), Some(".[].role"));
+    assert_eq!(t.partial, "ad");
+}
+
+#[test]
+fn cursor_at_opening_quote_returns_empty_partial() {
+    let q = "select(.status == \"";
+    let t = classify(q, q.len()).expect("trigger");
+    assert_eq!(t.partial, "");
+    assert_eq!(t.kind, TriggerKind::Eq);
+}
+
+#[test]
+fn unmatched_earlier_close_quotes_dont_confuse() {
+    // The LHS of the pipe is an array literal `["a", "b"]`, not a path.
+    // Folding can't anchor `.x` to a root-relative path, so lhs_path is None
+    // and the dispatcher falls through to the global string list. The
+    // important guarantee is that the trigger STILL fires (kind + partial
+    // are correct) — i.e. the unbalanced earlier quotes don't confuse the
+    // active-string detector.
+    let q = "[\"a\", \"b\"] | select(.x == \"y";
+    let t = classify(q, q.len()).expect("trigger");
+    assert_eq!(t.kind, TriggerKind::Eq);
+    assert!(t.lhs_path.is_none());
+    assert_eq!(t.partial, "y");
+}
+
+#[test]
+fn utf8_partial_preserved() {
+    let q = "select(.name == \"üñ";
+    let t = classify(q, q.len()).expect("trigger");
+    assert_eq!(t.partial, "üñ");
+    assert!(matches!(t.kind, TriggerKind::Eq));
+}
+
+#[test]
+fn cursor_in_middle_of_query() {
+    let q = "select(.x == \"ab\") | length";
+    let cursor = q.find("ab").unwrap() + 2;
+    let t = classify(q, cursor).expect("trigger");
+    assert_eq!(t.partial, "ab");
+}
+
+#[test]
+fn cursor_outside_string_in_middle() {
+    let q = "select(.x == \"ab\") | length";
+    let cursor = q.len();
+    assert!(classify(q, cursor).is_none());
+}
+
+#[test]
+fn array_index_lhs_path_preserved() {
+    let t = classify_at_end(".items[0].name == \"x").expect("trigger");
+    assert_eq!(t.lhs_path.as_deref(), Some(".items[0].name"));
+}
+
+#[test]
+fn array_iterator_lhs_path_preserved() {
+    let t = classify_at_end(".items[].name == \"x").expect("trigger");
+    assert_eq!(t.lhs_path.as_deref(), Some(".items[].name"));
+}
+
+#[test]
+fn optional_field_lhs_path_preserved() {
+    let t = classify_at_end(".user.role? == \"x").expect("trigger");
+    assert_eq!(t.lhs_path.as_deref(), Some(".user.role?"));
+}
+
+#[test]
+fn cursor_byte_clamped_to_char_boundary() {
+    let q = "select(.x == \"ü";
+    // Pass a cursor mid-codepoint; classify must clamp instead of panicking.
+    let mid = q.len() - 1;
+    let _ = classify(q, mid);
+}
+
+#[test]
+fn pipe_chain_with_function_breaks_path_extraction() {
+    // We deliberately don't fold paths through map(.x); the plan calls this out
+    // as a known limitation. Verify None for the lhs_path here.
+    let t = classify_at_end(".users | map(.role) | contains(\"a").expect("trigger");
+    assert_eq!(t.kind, TriggerKind::Contains);
+    assert!(t.lhs_path.is_none());
+}
+
+#[test]
+fn classifier_returns_none_for_random_non_trigger_inputs() {
+    let cases = [
+        "",
+        ".",
+        ".a.b.c",
+        "map(.x)",
+        "select(.x)",
+        "1 + 2",
+        "if .x then .y else .z end",
+        "[1, 2, 3]",
+        "{a: .x}",
+        "\"already closed\"",
+    ];
+    for q in cases {
+        assert!(classify(q, q.len()).is_none(), "expected None for: {q}");
+    }
+}
+
+#[test]
+fn quote_open_byte_points_at_opening_quote() {
+    let q = "select(.x == \"ab";
+    let t = classify(q, q.len()).expect("trigger");
+    assert_eq!(&q[t.quote_open_byte..t.quote_open_byte + 1], "\"");
+}
+
+#[test]
+fn ignores_comparison_inside_already_closed_strings() {
+    let q = "\"x == y\" | length";
+    assert!(classify(q, q.len()).is_none());
+}
+
+#[test]
+fn does_not_confuse_paren_inside_string() {
+    let q = "\"(\" + .x == \"ab";
+    let t = classify(q, q.len()).expect("trigger");
+    assert_eq!(t.kind, TriggerKind::Eq);
+    assert_eq!(t.lhs_path.as_deref(), Some(".x"));
+}
+
+// === Pipe-fold tests: produce ABSOLUTE paths rooted at the JSON root ===
+
+#[test]
+fn fold_pattern_a_top_level_field() {
+    // Pattern A: `.status == "`
+    let t = classify_at_end(".status == \"a").expect("trigger");
+    assert_eq!(t.lhs_path.as_deref(), Some(".status"));
+}
+
+#[test]
+fn fold_pattern_b_nested_field() {
+    // Pattern B: `.user.role == "`
+    let t = classify_at_end(".user.role == \"a").expect("trigger");
+    assert_eq!(t.lhs_path.as_deref(), Some(".user.role"));
+}
+
+#[test]
+fn fold_pattern_c_array_iteration_into_field() {
+    // Pattern C: `.users[].role == "`
+    let t = classify_at_end(".users[].role == \"a").expect("trigger");
+    assert_eq!(t.lhs_path.as_deref(), Some(".users[].role"));
+}
+
+#[test]
+fn fold_pattern_d_pipe_select_eq() {
+    // Pattern D: `.users[] | select(.role == "`
+    let t = classify_at_end(".users[] | select(.role == \"a").expect("trigger");
+    assert_eq!(t.lhs_path.as_deref(), Some(".users[].role"));
+}
+
+#[test]
+fn fold_pattern_e_pipe_select_contains() {
+    // Pattern E: `.Output.attributes[] | select(.attr | contains("`
+    let t = classify_at_end(".Output.attributes[] | select(.attr | contains(\"a").expect("trigger");
+    assert_eq!(t.kind, TriggerKind::Contains);
+    assert_eq!(t.lhs_path.as_deref(), Some(".Output.attributes[].attr"));
+}
+
+#[test]
+fn fold_pattern_f_pipe_map_contains() {
+    // Pattern F: `.users | map(.role) | contains("`
+    // The classifier doesn't fold past `map(.role)` (the LHS of the second
+    // pipe is a call expression, not a plain path chain). Falls back to None.
+    let t = classify_at_end(".users | map(.role) | contains(\"a").expect("trigger");
+    assert_eq!(t.kind, TriggerKind::Contains);
+    assert!(t.lhs_path.is_none());
+}
+
+#[test]
+fn fold_pattern_g_map_with_select_inside() {
+    // Pattern G: `.users[] | map(select(.active == "`
+    // Walks out: select (identity) → map (prepend []) → pipe → .users[]
+    // Result: .users[][].active
+    let t = classify_at_end(".users[] | map(select(.active == \"t").expect("trigger");
+    assert_eq!(t.lhs_path.as_deref(), Some(".users[][].active"));
+}
+
+#[test]
+fn fold_pattern_h_multi_pipe() {
+    // Pattern H: `.a.b | .c | select(.d == "`
+    let t = classify_at_end(".a.b | .c | select(.d == \"x").expect("trigger");
+    assert_eq!(t.lhs_path.as_deref(), Some(".a.b.c.d"));
+}
+
+#[test]
+fn fold_pattern_i_nested_select() {
+    // Pattern I: `.users[] | select(.profile | select(.role == "`
+    let t = classify_at_end(".users[] | select(.profile | select(.role == \"a").expect("trigger");
+    assert_eq!(t.lhs_path.as_deref(), Some(".users[].profile.role"));
+}
+
+#[test]
+fn fold_pattern_j_array_index_then_pipe() {
+    // Pattern J: `.items[0] | select(.name == "`
+    let t = classify_at_end(".items[0] | select(.name == \"a").expect("trigger");
+    assert_eq!(t.lhs_path.as_deref(), Some(".items[0].name"));
+}
+
+#[test]
+fn fold_pattern_k_top_level_no_lhs() {
+    // Pattern K: `contains("` — no LHS at all
+    let t = classify_at_end("contains(\"a").expect("trigger");
+    assert_eq!(t.kind, TriggerKind::Contains);
+    assert!(t.lhs_path.is_none());
+}
+
+#[test]
+fn fold_pattern_l_eq_no_lhs() {
+    // Pattern L: `== "` — no LHS at all
+    let t = classify_at_end("== \"a").expect("trigger");
+    assert_eq!(t.kind, TriggerKind::Eq);
+    assert!(t.lhs_path.is_none());
+}
+
+#[test]
+fn fold_pattern_m_filter_narrowing_does_not_propagate() {
+    // Pattern M: `select(.year > 2020) | select(.title == "`
+    // The first select's predicate narrows the stream but its body is
+    // opaque to the fold (it's just a boolean expr, not a path-prefix).
+    // The fold for the inner select walks out: select (identity) → pipe →
+    // need a path on the left. The left of the pipe is a call expression,
+    // so the fold gives up cleanly. Documented limitation.
+    let t = classify_at_end("select(.year > 2020) | select(.title == \"a").expect("trigger");
+    assert!(t.lhs_path.is_none());
+}
+
+#[test]
+fn fold_pattern_n_reduce_gives_up() {
+    // Pattern N: `reduce .items[] as $i (init; $i | select(.x == "`
+    // The cursor is inside a reduce's body. Folding hits `reduce` (not in
+    // identity/iterating wrapper sets) and gives up.
+    let t = classify_at_end("reduce .items[] as $i (0; $i | select(.x == \"a").expect("trigger");
+    assert!(t.lhs_path.is_none());
+}
+
+#[test]
+fn fold_pattern_q_sort_by_breaks_fold() {
+    // Pattern Q: `.items | sort_by(.date) | .[0] | select(.title == "`
+    // sort_by isn't in our wrapper sets. The fold hits the call expression
+    // on the left of the second pipe and gives up.
+    let t =
+        classify_at_end(".items | sort_by(.date) | .[0] | select(.title == \"a").expect("trigger");
+    assert!(t.lhs_path.is_none());
+}
+
+#[test]
+fn fold_through_pipe_with_bare_identifier() {
+    // `.users[] | first | select(.role == "` — bare `first` between pipes.
+    // The fold walks out of select (identity), hits a pipe, and
+    // `extract_path_chain_ending_at` looks for path bytes ending at that
+    // pipe. `first` is identifier chars but doesn't start with `.`, so the
+    // chain extraction fails and the fold gives up cleanly. Documented
+    // limitation — bare-identifier wrappers between pipes aren't folded.
+    let t = classify_at_end(".users[] | first | select(.role == \"a").expect("trigger");
+    assert!(t.lhs_path.is_none());
+}
+
+#[test]
+fn fold_pipe_to_select_with_no_inner_path() {
+    // `.users[] | select("` — partial inside select with no LHS path inside.
+    // No EQ/NE, no STRING_PREDICATE → no trigger fires.
+    assert!(classify_at_end(".users[] | select(\"a").is_none());
+}
+
+#[test]
+fn fold_recursion_safety_bounded() {
+    // Many nested selects shouldn't blow up. The fold has a 32-hop ceiling.
+    let mut q = String::new();
+    for _ in 0..50 {
+        q.push_str("select(");
+    }
+    q.push_str(".x == \"a");
+    // Whether it folds or returns None, it must not panic or hang.
+    let _ = classify(&q, q.len());
+}

--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::process::{Command, Stdio};
 use std::sync::{Arc, OnceLock};
 use std::thread::sleep;
@@ -24,8 +24,18 @@ pub struct JqExecutor {
     /// All unique field names from the JSON, collected recursively.
     /// Cached for non-deterministic autocomplete fallback.
     all_field_names: OnceLock<Arc<HashSet<String>>>,
+    /// All distinct string VALUES from the JSON, collected recursively,
+    /// sorted by descending frequency (alphabetical tiebreaker), capped at
+    /// `MAX_GLOBAL_STRING_VALUES`. Used as the last-resort fallback by
+    /// string-value autocomplete.
+    all_string_values: OnceLock<Arc<Vec<String>>>,
     array_sample_size: usize,
 }
+
+/// Cap on distinct values returned by `all_string_values`. Keeps the lazy
+/// precompute bounded on pathological JSON (e.g. log dumps with millions of
+/// unique IDs).
+pub const MAX_GLOBAL_STRING_VALUES: usize = 10_000;
 
 impl JqExecutor {
     /// Create a new JQ executor with JSON input and default sample size
@@ -39,6 +49,7 @@ impl JqExecutor {
             json_input: Arc::new(json_input),
             json_input_parsed: OnceLock::new(),
             all_field_names: OnceLock::new(),
+            all_string_values: OnceLock::new(),
             array_sample_size,
         }
     }
@@ -96,6 +107,57 @@ impl JqExecutor {
                 }
             }
             _ => {}
+        }
+    }
+
+    /// Get all distinct string VALUES from the JSON, sorted by descending
+    /// frequency (alphabetical tiebreaker), capped at `MAX_GLOBAL_STRING_VALUES`.
+    ///
+    /// Lazy precompute via `OnceLock`. The first caller pays the walk cost
+    /// once per session; subsequent callers get an `Arc::clone`. Mirrors
+    /// `all_field_names()` but for string values rather than keys.
+    pub fn all_string_values(&self) -> Arc<Vec<String>> {
+        self.all_string_values
+            .get_or_init(|| {
+                let mut counts: HashMap<String, u32> = HashMap::new();
+                if let Some(parsed) = self.json_input_parsed() {
+                    Self::collect_string_values_recursive(&parsed, &mut counts);
+                }
+                Arc::new(sort_and_cap_strings(counts, MAX_GLOBAL_STRING_VALUES))
+            })
+            .clone()
+    }
+
+    fn collect_string_values_recursive(value: &Value, counts: &mut HashMap<String, u32>) {
+        // Iterative DFS to avoid stack overflow on deeply nested JSON.
+        let mut stack: Vec<&Value> = vec![value];
+        while let Some(node) = stack.pop() {
+            if counts.len() >= MAX_GLOBAL_STRING_VALUES {
+                // Don't add NEW distinct values past the cap, but keep walking
+                // so we accumulate frequency for already-seen strings. (Walking
+                // unbounded JSON for this is intentional — caller is gated by
+                // OnceLock so this only ever runs once.)
+            }
+            match node {
+                Value::String(s) => {
+                    if let Some(c) = counts.get_mut(s.as_str()) {
+                        *c += 1;
+                    } else if counts.len() < MAX_GLOBAL_STRING_VALUES {
+                        counts.insert(s.clone(), 1);
+                    }
+                }
+                Value::Array(arr) => {
+                    for element in arr {
+                        stack.push(element);
+                    }
+                }
+                Value::Object(map) => {
+                    for (_, v) in map {
+                        stack.push(v);
+                    }
+                }
+                _ => {}
+            }
         }
     }
 
@@ -236,6 +298,13 @@ impl JqExecutor {
             Err(QueryError::ExecutionFailed(stderr_str))
         }
     }
+}
+
+fn sort_and_cap_strings(counts: HashMap<String, u32>, cap: usize) -> Vec<String> {
+    let mut entries: Vec<(String, u32)> = counts.into_iter().collect();
+    entries.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    entries.truncate(cap);
+    entries.into_iter().map(|(s, _)| s).collect()
 }
 
 #[cfg(test)]

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -403,6 +403,7 @@ pub mod autocomplete {
     pub const TYPE_OPERATOR: Color = Color::Rgb(198, 120, 221);
     pub const TYPE_PATTERN: Color = Color::Rgb(107, 203, 119);
     pub const TYPE_VARIABLE: Color = Color::Rgb(224, 108, 117);
+    pub const TYPE_VALUE: Color = Color::Rgb(232, 165, 90);
 }
 
 /// Tooltip styles

--- a/tests/value_collector_perf.rs
+++ b/tests/value_collector_perf.rs
@@ -1,0 +1,91 @@
+//! Performance gate for the value-autocomplete data sources.
+//!
+//! Builds a ~10 MB synthetic JSON in-memory and asserts:
+//! - The lazy `JqExecutor::all_string_values()` precompute fits within budget
+//!   on first call (it runs synchronously on the keystroke that triggers
+//!   value autocomplete with no path-scoped match).
+//! - Subsequent accesses are zero-cost (Arc clone only).
+
+use jiq::autocomplete::value_collector::collect_distinct_strings;
+use jiq::query::executor::JqExecutor;
+use serde_json::{Value, json};
+use std::time::Instant;
+
+const TARGET_OBJECTS: usize = 100_000;
+const STATUSES: &[&str] = &[
+    "active", "inactive", "pending", "archived", "draft", "review", "approved", "rejected",
+];
+
+fn build_fixture() -> String {
+    let pad: String = "x".repeat(64);
+    let mut arr = Vec::with_capacity(TARGET_OBJECTS);
+    for i in 0..TARGET_OBJECTS {
+        arr.push(json!({
+            "status": STATUSES[i % STATUSES.len()],
+            "blob": pad,
+        }));
+    }
+    serde_json::to_string(&Value::Array(arr)).expect("serialize fixture")
+}
+
+// Perf budgets are deliberately loose so coverage / debug runs (which can be
+// 5-10x slower than release) don't flake. The release binary easily beats
+// these by an order of magnitude.
+
+#[test]
+fn all_string_values_first_call_completes() {
+    let json = build_fixture();
+    let executor = JqExecutor::new(json);
+    let start = Instant::now();
+    let values = executor.all_string_values();
+    let elapsed = start.elapsed();
+    assert!(!values.is_empty());
+    assert!(
+        elapsed.as_secs() < 30,
+        "all_string_values first call took {:?} on 10MB fixture (budget: 30s; expect <50ms in release)",
+        elapsed
+    );
+    eprintln!("all_string_values first call: {:?}", elapsed);
+}
+
+#[test]
+fn all_string_values_warm_call_is_arc_clone() {
+    let json = build_fixture();
+    let executor = JqExecutor::new(json);
+    let _ = executor.all_string_values();
+    let start = Instant::now();
+    for _ in 0..100_000 {
+        let _ = executor.all_string_values();
+    }
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed.as_secs() < 5,
+        "100k warm calls took {:?} (budget: 5s for debug/coverage; expect <50ms in release)",
+        elapsed
+    );
+    eprintln!("100k warm calls: {:?}", elapsed);
+}
+
+#[test]
+fn collect_distinct_strings_on_navigated_values() {
+    // Simulate the per-keystroke walk on a 100k-element array path.
+    let parsed: Value = serde_json::from_str(&build_fixture()).expect("parse fixture");
+    let arr = match &parsed {
+        Value::Array(a) => a,
+        _ => panic!("expected array"),
+    };
+    let navigated: Vec<&Value> = arr
+        .iter()
+        .filter_map(|el| el.as_object().and_then(|m| m.get("status")))
+        .collect();
+    let start = Instant::now();
+    let strings = collect_distinct_strings(&navigated);
+    let elapsed = start.elapsed();
+    assert_eq!(strings.len(), STATUSES.len());
+    assert!(
+        elapsed.as_secs() < 10,
+        "collect_distinct_strings on 100k values took {:?} (budget: 10s for debug/coverage; expect <50ms in release)",
+        elapsed
+    );
+    eprintln!("collect_distinct_strings on 100k: {:?}", elapsed);
+}


### PR DESCRIPTION
## Summary
- Suggest distinct string values from the loaded JSON when typing inside an unclosed `"..."` at a value-comparison position (`==`, `!=`, `contains`, `startswith`, `endswith`, `inside`, `IN`, `has`, `in`).
- Classifier folds the surrounding pipe/`select`/`map` context into an absolute path so `.users[] | select(.role == "` suggests roles found at `.users[].role` — not the firehose.
- Falls back to a precomputed global string list when the path can't be folded (regex argument functions, user-defined functions, `reduce`/`foreach`, etc. — all out of scope cleanly).
- Insertion handles UTF-8, escaping `\"` and `\\`, and avoids double-closing quotes.

## Test plan
- [x] cargo test (3481 unit + 5 + 25 + 3 perf + 4 = 3518 tests, all green)
- [x] cargo build --release (zero warnings)
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo fmt --all --check
- [x] Manual TUI validation against real-world streaming queries