### PR TITLE
fix(ai): ignore stale cancellations so popup keeps showing progress

### DIFF
--- a/src/ai/ai_events.rs
+++ b/src/ai/ai_events.rs
@@ -220,9 +220,10 @@ pub fn handle_query_result<T: ToString>(
 /// Filters stale responses by checking request_id against the current
 /// AiState request_id. Responses from old requests are ignored.
 ///
-/// Note: `AiResponse::Cancelled` does not require request_id comparison because
-/// token-based cancellation ensures the response is always for the request that
-/// was actually cancelled. The CancellationToken is tied to a specific request.
+/// This applies to every variant that carries a request_id, including
+/// `Cancelled`: although the CancellationToken is tied to a specific request,
+/// the `Cancelled` message still travels the same channel and can arrive after
+/// a newer request has started, so it must be compared like the others.
 fn process_response(ai_state: &mut AiState, response: AiResponse) {
     let current_request_id = ai_state.current_request_id();
 
@@ -242,10 +243,19 @@ fn process_response(ai_state: &mut AiState, response: AiResponse) {
         AiResponse::Error(error_msg) => {
             ai_state.set_error(error_msg);
         }
-        // Token-based cancellation: no request_id comparison needed.
-        // The CancellationToken is tied to a specific request, so when
-        // we receive Cancelled, it's always for the request we cancelled.
-        AiResponse::Cancelled { request_id: _ } => {
+        // A Cancelled response for a request that has already been superseded
+        // must be ignored: cancelling an old in-flight request (e.g. when the
+        // user keeps typing) would otherwise clear `loading` while the newer
+        // request is still streaming, blanking the popup until it completes.
+        AiResponse::Cancelled { request_id } => {
+            if request_id < current_request_id {
+                log::debug!(
+                    "AI Cancelled ignored (stale): id={} current={}",
+                    request_id,
+                    current_request_id
+                );
+                return;
+            }
             ai_state.loading = false;
             ai_state.in_flight_request_id = None;
         }

--- a/src/ai/ai_events_tests/query_result_tests.rs
+++ b/src/ai/ai_events_tests/query_result_tests.rs
@@ -123,6 +123,38 @@ fn test_poll_processes_cancelled() {
 }
 
 #[test]
+fn test_poll_ignores_stale_cancelled_while_newer_request_in_flight() {
+    // Regression: a Cancelled response for an old, superseded request must not
+    // clear `loading` while a newer request is still streaming. Otherwise the
+    // popup drops out of the "Thinking..." state and renders a blank box until
+    // the newer request completes.
+    let mut ai_state = AiState::new(true);
+    let (tx, rx) = mpsc::channel();
+    ai_state.response_rx = Some(rx);
+
+    // First request (will be superseded).
+    ai_state.start_request();
+    let stale_id = ai_state.current_request_id();
+
+    // Newer request supersedes it; this is the in-flight one.
+    ai_state.start_request();
+    let current_id = ai_state.current_request_id();
+    assert!(current_id > stale_id);
+
+    // The stale request's cancellation arrives after the newer one started.
+    tx.send(AiResponse::Cancelled {
+        request_id: stale_id,
+    })
+    .unwrap();
+
+    poll_response_channel(&mut ai_state);
+
+    // Newer request is untouched: still loading, still tracked in-flight.
+    assert!(ai_state.loading, "stale cancel must not clear loading");
+    assert_eq!(ai_state.in_flight_request_id, Some(current_id));
+}
+
+#[test]
 fn test_poll_handles_disconnected_channel() {
     let mut ai_state = AiState::new(true);
     let (tx, rx) = mpsc::channel::<AiResponse>();

--- a/src/ai/ai_state/lifecycle.rs
+++ b/src/ai/ai_state/lifecycle.rs
@@ -146,6 +146,10 @@ impl AiState {
                     );
                 }
             }
+        } else {
+            // No bytes received before completion: all classification flags stay
+            // clear, so the popup renders empty until the next query.
+            log::debug!("complete_request: empty response, popup will be blank until next query");
         }
 
         self.selection.clear_layout();

--- a/src/ai/render/content.rs
+++ b/src/ai/render/content.rs
@@ -147,5 +147,17 @@ pub fn build_content(ai_state: &AiState, max_width: u16) -> Text<'static> {
         return Text::from(lines);
     }
 
+    // Canary: every earlier branch returned, so the popup is about to render an
+    // empty box. This should be rare; if it shows up in a --debug session it
+    // signals a state combination that leaves the user with no feedback.
+    log::debug!(
+        "build_content: empty popup (no branch matched) -> loading={} suggestions={} no_suggestions={} parse_failed={} error={}",
+        ai_state.loading,
+        ai_state.suggestions.len(),
+        ai_state.no_suggestions,
+        ai_state.parse_failed,
+        ai_state.error.is_some()
+    );
+
     Text::from(lines)
 }


### PR DESCRIPTION
## Summary
- Fix the AI suggestion popup going blank mid-request. When the user kept typing, the in-flight AI request was cancelled and a newer one started; the old request's `AiResponse::Cancelled` then arrived and cleared `loading` even though the newer request was still streaming, dropping `build_content` into its empty fall-through. The popup rendered an empty bordered box for the entire stream until the new request completed.
- The `Cancelled` arm of `process_response` now applies the same `request_id < current_request_id` staleness guard already used by the `Chunk` and `Complete` arms, so a superseded cancellation can no longer clear `loading` out from under a live request. The popup holds "Thinking..." until suggestions render.
- Added a regression test (`test_poll_ignores_stale_cancelled_while_newer_request_in_flight`) and a few debug-level canaries (free in release without `--debug`) that flag any future empty-popup state.

## Test plan
- [x] cargo test (full suite, 3576+ tests, 0 failures)
- [x] cargo build --release (zero warnings)
- [x] cargo build (debug; zero warnings)
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo fmt --all --check
- [x] Manual TUI validation (reproduced via --debug; blank box no longer appears)