### PR TITLE
feat: move tooltip toggle to ctrl+i and make ctrl+t a context-aware pane focus toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Tooltip toggle moves to `Ctrl+I`; `Ctrl+T` becomes a focus toggle between the query input and the results pane.** The previous `Ctrl+T` shortcut for showing/hiding the function tooltip now lives at `Ctrl+I` (mnemonic: "info"). `Ctrl+T` joins `Shift+Tab` as a second way to bounce focus between the two main panes, freeing the tooltip toggle from a key that overlapped a "switch panes" mental model. On-screen border hints, the F1 help window, README, and the docs site (`quick-reference`, `features/tooltip`, `configuration`) all reflect the new bindings.
+- **Bottom-border focus hint now advertises `Ctrl+T` and reads context-aware.** The pane's bottom-border strip previously showed `Shift+Tab Navigate Results` (on the query input) and `Tab Edit Query` (on the results pane). It now leads with `Ctrl+T`, switching its label by context: `Ctrl+T Navigate Results` while the query input is focused, `Ctrl+T Edit Query` while the results pane is focused (the global help-line strip updates to match). `Shift+Tab` and `Tab` still work as before - this only changes which key the on-screen hint promotes.
+
 ## [3.32.1] - 2026-05-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -112,12 +112,12 @@ jiq --paste
 | Key | Action |
 |-----|--------|
 | `F1` or `?` | Toggle keyboard shortcuts help popup |
-| `Shift+Tab` | Switch focus between Input and Results |
+| `Shift+Tab` / `Ctrl+T` | Switch focus between Input and Results |
 | `Ctrl+Y` | Copy current query or results to clipboard (focus-aware) |
 | `Ctrl+O` | Copy results to clipboard regardless of focus |
 | `Ctrl+W` | Save result to file (live path preview, overwrite warning) |
 | `yy` | Copy current query or results to clipboard (NORMAL mode) |
-| `Ctrl+T` | Toggle function tooltip (when cursor is on a function) |
+| `Ctrl+I` | Toggle function tooltip (when cursor is on a function) |
 | `Ctrl+E` | Toggle error overlay (when syntax error exists) |
 | `Ctrl+A` | Toggle AI assistant popup |
 | `Enter` | Exit and output filtered JSON |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Tooltip toggle moves to `Ctrl+I`; `Ctrl+T` becomes a focus toggle between the query input and the results pane.** The previous `Ctrl+T` shortcut for showing/hiding the function tooltip now lives at `Ctrl+I` (mnemonic: "info"). `Ctrl+T` joins `Shift+Tab` as a second way to bounce focus between the two main panes, freeing the tooltip toggle from a key that overlapped a "switch panes" mental model. On-screen border hints, the F1 help window, README, and the docs site (`quick-reference`, `features/tooltip`, `configuration`) all reflect the new bindings.
+- **Bottom-border focus hint now advertises `Ctrl+T` and reads context-aware.** The pane's bottom-border strip previously showed `Shift+Tab Navigate Results` (on the query input) and `Tab Edit Query` (on the results pane). It now leads with `Ctrl+T`, switching its label by context: `Ctrl+T Navigate Results` while the query input is focused, `Ctrl+T Edit Query` while the results pane is focused (the global help-line strip updates to match). `Shift+Tab` and `Tab` still work as before - this only changes which key the on-screen hint promotes.
+
 ## [3.32.1] - 2026-05-31
 
 ### Fixed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,7 @@ For heterogeneous arrays, increase to union more keys (range: 1–1000).
 auto_show = true
 ```
 
-When `true` (default), the function tooltip appears automatically as the cursor lands on a known jq function. Set to `false` to require <kbd>Ctrl</kbd>+<kbd>T</kbd> to open it.
+When `true` (default), the function tooltip appears automatically as the cursor lands on a known jq function. Set to `false` to require <kbd>Ctrl</kbd>+<kbd>I</kbd> to open it.
 
 ## AI
 

--- a/docs/features/tooltip.md
+++ b/docs/features/tooltip.md
@@ -43,7 +43,7 @@ Move your cursor onto any jq function name in the query input. A tooltip appears
 - Return type information
 - An inline example
 
-Press <kbd>Ctrl</kbd>+<kbd>T</kbd> to toggle the tooltip on or off manually.
+Press <kbd>Ctrl</kbd>+<kbd>I</kbd> to toggle the tooltip on or off manually.
 
 To disable auto-show, add to `~/.config/jiq/config.toml`:
 
@@ -93,7 +93,7 @@ Click any tab header to switch, or press <kbd>Esc</kbd> to close.
 
 | Key | Action |
 |---|---|
-| `Ctrl+T` | Toggle function tooltip |
+| `Ctrl+I` | Toggle function tooltip |
 | `Ctrl+E` | Toggle error overlay |
 | `F1` / `?` | Toggle help popup |
 | `Esc` | Close any overlay |

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -14,11 +14,11 @@ Every keybind in one place. Click any section header for the full guide.
 | Key | Action |
 |:---|:---|
 | <kbd>F1</kbd> / <kbd>?</kbd> | Toggle help popup |
-| <kbd>Shift</kbd>+<kbd>Tab</kbd> | Switch focus: input ↔ results |
+| <kbd>Shift</kbd>+<kbd>Tab</kbd> / <kbd>Ctrl</kbd>+<kbd>T</kbd> | Switch focus: input ↔ results |
 | <kbd>Ctrl</kbd>+<kbd>Y</kbd> | Copy (focus-aware: query if input, results if results) |
 | <kbd>Ctrl</kbd>+<kbd>O</kbd> | Copy results (regardless of focus) |
 | <kbd>Ctrl</kbd>+<kbd>W</kbd> | [Save result to file](./features/save) |
-| <kbd>Ctrl</kbd>+<kbd>T</kbd> | Toggle [function tooltip](./features/tooltip) |
+| <kbd>Ctrl</kbd>+<kbd>I</kbd> | Toggle [function tooltip](./features/tooltip) |
 | <kbd>Ctrl</kbd>+<kbd>E</kbd> | Toggle [error overlay](./features/results-pane#decode-an-error) (plain-language jq errors) |
 | <kbd>Ctrl</kbd>+<kbd>A</kbd> | Toggle [AI assistant](./features/ai-assistant) |
 | <kbd>Ctrl</kbd>+<kbd>S</kbd> | Open [snippets](./features/snippets) |

--- a/src/app/app_events.rs
+++ b/src/app/app_events.rs
@@ -191,8 +191,9 @@ fn handle_popup_passthrough_keys(app: &mut App, key: KeyEvent) -> bool {
         }
     }
 
-    // BackTab closes history and switches focus
-    if key.code == KeyCode::BackTab && app.history.is_visible() {
+    // BackTab and Ctrl+T close history and switch focus
+    let is_ctrl_t = key.code == KeyCode::Char('t') && key.modifiers.contains(KeyModifiers::CONTROL);
+    if (key.code == KeyCode::BackTab || is_ctrl_t) && app.history.is_visible() {
         app.history.close();
         app.focus = match app.focus {
             Focus::InputField => Focus::ResultsPane,

--- a/src/app/app_events/global.rs
+++ b/src/app/app_events/global.rs
@@ -168,8 +168,19 @@ pub fn handle_global_keys(app: &mut App, key: KeyEvent) -> bool {
             true
         }
 
-        KeyCode::Char('t') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+        KeyCode::Char('i') if key.modifiers.contains(KeyModifiers::CONTROL) => {
             crate::tooltip::tooltip_events::handle_tooltip_toggle(&mut app.tooltip);
+            true
+        }
+
+        KeyCode::Char('t') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            if app.history.is_visible() {
+                app.history.close();
+            }
+            match app.focus {
+                Focus::InputField => app.focus_results_pane(),
+                Focus::ResultsPane => app.focus_input_field(),
+            };
             true
         }
 

--- a/src/app/app_events/global_tests/global_key_tests.rs
+++ b/src/app/app_events/global_tests/global_key_tests.rs
@@ -536,7 +536,51 @@ fn test_backtab_round_trip_preserves_popup_state() {
     assert!(app.tooltip.enabled);
 }
 
-// ========== Tooltip Toggle Tests (Ctrl+T) ==========
+// ========== Focus Toggle Tests (Ctrl+T) ==========
+
+#[test]
+fn test_ctrl_t_switches_focus_input_to_results() {
+    let mut app = app_with_query(".");
+    app.focus = Focus::InputField;
+
+    app.handle_key_event(key_with_mods(KeyCode::Char('t'), KeyModifiers::CONTROL));
+    assert_eq!(app.focus, Focus::ResultsPane);
+}
+
+#[test]
+fn test_ctrl_t_switches_focus_results_to_input() {
+    let mut app = app_with_query(".");
+    app.focus = Focus::ResultsPane;
+
+    app.handle_key_event(key_with_mods(KeyCode::Char('t'), KeyModifiers::CONTROL));
+    assert_eq!(app.focus, Focus::InputField);
+}
+
+#[test]
+fn test_ctrl_t_round_trip_focus() {
+    let mut app = app_with_query(".");
+    app.focus = Focus::InputField;
+
+    app.handle_key_event(key_with_mods(KeyCode::Char('t'), KeyModifiers::CONTROL));
+    app.handle_key_event(key_with_mods(KeyCode::Char('t'), KeyModifiers::CONTROL));
+    assert_eq!(app.focus, Focus::InputField);
+}
+
+#[test]
+fn test_ctrl_t_closes_history_when_switching_focus() {
+    let mut app = app_with_query("");
+    app.input.editor_mode = EditorMode::Insert;
+    app.history.add_entry_in_memory(".foo");
+    app.handle_key_event(key_with_mods(KeyCode::Char('r'), KeyModifiers::CONTROL));
+    assert!(app.history.is_visible());
+
+    app.handle_key_event(key_with_mods(KeyCode::Char('t'), KeyModifiers::CONTROL));
+
+    assert!(!app.history.is_visible());
+    assert_eq!(app.focus, Focus::ResultsPane);
+}
+
+// ========== Tooltip Toggle Tests (Ctrl+I) ==========
 
 #[test]
 fn test_tooltip_initializes_enabled() {
@@ -545,63 +589,63 @@ fn test_tooltip_initializes_enabled() {
 }
 
 #[test]
-fn test_ctrl_t_toggles_tooltip_from_enabled() {
+fn test_ctrl_i_toggles_tooltip_from_enabled() {
     let mut app = app_with_query(".");
     assert!(app.tooltip.enabled);
 
-    app.handle_key_event(key_with_mods(KeyCode::Char('t'), KeyModifiers::CONTROL));
+    app.handle_key_event(key_with_mods(KeyCode::Char('i'), KeyModifiers::CONTROL));
     assert!(!app.tooltip.enabled);
 }
 
 #[test]
-fn test_ctrl_t_toggles_tooltip_from_disabled() {
+fn test_ctrl_i_toggles_tooltip_from_disabled() {
     let mut app = app_with_query(".");
     app.tooltip.toggle(); // disable first
     assert!(!app.tooltip.enabled);
 
-    app.handle_key_event(key_with_mods(KeyCode::Char('t'), KeyModifiers::CONTROL));
+    app.handle_key_event(key_with_mods(KeyCode::Char('i'), KeyModifiers::CONTROL));
     assert!(app.tooltip.enabled);
 }
 
 #[test]
-fn test_ctrl_t_works_in_insert_mode() {
+fn test_ctrl_i_works_in_insert_mode() {
     let mut app = app_with_query(".");
     app.input.editor_mode = EditorMode::Insert;
     app.focus = Focus::InputField;
     assert!(app.tooltip.enabled);
 
-    app.handle_key_event(key_with_mods(KeyCode::Char('t'), KeyModifiers::CONTROL));
+    app.handle_key_event(key_with_mods(KeyCode::Char('i'), KeyModifiers::CONTROL));
     assert!(!app.tooltip.enabled);
 }
 
 #[test]
-fn test_ctrl_t_works_in_normal_mode() {
+fn test_ctrl_i_works_in_normal_mode() {
     let mut app = app_with_query(".");
     app.input.editor_mode = EditorMode::Normal;
     app.focus = Focus::InputField;
     assert!(app.tooltip.enabled);
 
-    app.handle_key_event(key_with_mods(KeyCode::Char('t'), KeyModifiers::CONTROL));
+    app.handle_key_event(key_with_mods(KeyCode::Char('i'), KeyModifiers::CONTROL));
     assert!(!app.tooltip.enabled);
 }
 
 #[test]
-fn test_ctrl_t_works_when_results_pane_focused() {
+fn test_ctrl_i_works_when_results_pane_focused() {
     let mut app = app_with_query(".");
     app.focus = Focus::ResultsPane;
     assert!(app.tooltip.enabled);
 
-    app.handle_key_event(key_with_mods(KeyCode::Char('t'), KeyModifiers::CONTROL));
+    app.handle_key_event(key_with_mods(KeyCode::Char('i'), KeyModifiers::CONTROL));
     assert!(!app.tooltip.enabled);
 }
 
 #[test]
-fn test_ctrl_t_preserves_current_function() {
+fn test_ctrl_i_preserves_current_function() {
     let mut app = app_with_query("select(.x)");
     app.tooltip.set_current_function(Some("select".to_string()));
     assert!(app.tooltip.enabled);
 
-    app.handle_key_event(key_with_mods(KeyCode::Char('t'), KeyModifiers::CONTROL));
+    app.handle_key_event(key_with_mods(KeyCode::Char('i'), KeyModifiers::CONTROL));
 
     // Should toggle enabled but preserve current_function
     assert!(!app.tooltip.enabled);
@@ -609,13 +653,13 @@ fn test_ctrl_t_preserves_current_function() {
 }
 
 #[test]
-fn test_ctrl_t_round_trip() {
+fn test_ctrl_i_round_trip() {
     let mut app = app_with_query(".");
     let initial_enabled = app.tooltip.enabled;
 
     // Toggle twice should return to original state
-    app.handle_key_event(key_with_mods(KeyCode::Char('t'), KeyModifiers::CONTROL));
-    app.handle_key_event(key_with_mods(KeyCode::Char('t'), KeyModifiers::CONTROL));
+    app.handle_key_event(key_with_mods(KeyCode::Char('i'), KeyModifiers::CONTROL));
+    app.handle_key_event(key_with_mods(KeyCode::Char('i'), KeyModifiers::CONTROL));
 
     assert_eq!(app.tooltip.enabled, initial_enabled);
 }

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_error_overlay.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_error_overlay.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 186
 expression: output
 ---
 "╭   ⚠ Syntax Error   Object | Showing last successful result ───── L1-3/3 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.foo[                                                                         │"
-"╰─────────────── Shift+Tab Navigate Results • Ctrl+E Show Error ───────────────╯"
+"╰──────────────── Ctrl+T Navigate Results • Ctrl+E Show Error ─────────────────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_initial_ui_empty_query.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_initial_ui_empty_query.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 16
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_results_pane_with_success_focused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_results_pane_with_success_focused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 254
 expression: output
 ---
 "╭ String  · . ──────────────────────────────────────────────────── L1-1/1 (0%) ╮"
@@ -21,8 +22,8 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰───── Ctrl+T Edit Query • i Edit Query • > value • * iterate • ^ parent ──────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"
-" F1/? Help • Shift+Tab Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Sav"
+" F1/? Help • Ctrl+T Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save •"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_results_pane_with_success_unfocused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_results_pane_with_success_unfocused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 239
 expression: output
 ---
 "╭ String ───────────────────────────────────────────────────────── L1-1/1 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
-"╰─── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───╯"
+"╰──── Ctrl+T Navigate Results • Enter Output Result • Ctrl+Q Output Query ─────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_results_pane_with_syntax_error_focused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_results_pane_with_syntax_error_focused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 224
 expression: output
 ---
 "╭   ⚠ Syntax Error   String | Showing last successful result ───── L1-1/1 (0%) ╮"
@@ -21,8 +22,8 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰───── Ctrl+T Edit Query • i Edit Query • > value • * iterate • ^ parent ──────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid[                                                                     │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"
-" F1/? Help • Shift+Tab Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Sav"
+" F1/? Help • Ctrl+T Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save •"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_results_pane_with_syntax_error_unfocused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_results_pane_with_syntax_error_unfocused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 205
 expression: output
 ---
 "╭   ⚠ Syntax Error   String | Showing last successful result ───── L1-1/1 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid[                                                                     │"
-"╰─────────────── Shift+Tab Navigate Results • Ctrl+E Show Error ───────────────╯"
+"╰──────────────── Ctrl+T Navigate Results • Ctrl+E Show Error ─────────────────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_stats_bar_array_focused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_stats_bar_array_focused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 267
 expression: output
 ---
 "╭ Array [3 objects]  · . ─────────────────────────────────────── L1-11/11 (0%) ╮"
@@ -21,8 +22,8 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰───── Ctrl+T Edit Query • i Edit Query • > value • * iterate • ^ parent ──────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"
-" F1/? Help • Shift+Tab Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Sav"
+" F1/? Help • Ctrl+T Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save •"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_stats_bar_error_shows_last_stats.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_stats_bar_error_shows_last_stats.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 296
 expression: output
 ---
 "╭   ⚠ Syntax Error   Array [5 numbers] | Showing last successful result 7 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid[                                                                     │"
-"╰─────────────── Shift+Tab Navigate Results • Ctrl+E Show Error ───────────────╯"
+"╰──────────────── Ctrl+T Navigate Results • Ctrl+E Show Error ─────────────────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_stats_bar_object_unfocused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_stats_bar_object_unfocused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 280
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_error_overlay_visible.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_error_overlay_visible.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 149
 expression: output
 ---
 "╭   ⚠ Syntax Error   Number | Showing last successful result ───── L1-1/1 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.foo                                                                          │"
-"╰─────────────── Shift+Tab Navigate Results • Ctrl+E Show Error ───────────────╯"
+"╰──────────────── Ctrl+T Navigate Results • Ctrl+E Show Error ─────────────────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_input_focused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_input_focused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 50
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_insert_mode.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_insert_mode.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 106
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_normal_mode.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_normal_mode.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 116
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [NORMAL] (press 'i' to edit) ───────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1/? Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_operator_mode.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_operator_mode.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 126
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [OPERATOR(d)] ──────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1/? Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_results_focused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_results_focused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 60
 expression: output
 ---
 "╭ Object  · . ──────────────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -21,8 +22,8 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰───── Ctrl+T Edit Query • i Edit Query • > value • * iterate • ^ parent ──────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"
-" F1/? Help • Shift+Tab Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Sav"
+" F1/? Help • Ctrl+T Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save •"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_results_horizontal_scroll_via_trackpad.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_results_horizontal_scroll_via_trackpad.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 96
 expression: output
 ---
 "╭ Object  · . ──────────────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -21,8 +22,8 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰───── Ctrl+T Edit Query • i Edit Query • > value • * iterate • ^ parent ──────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"
-" F1/? Help • Shift+Tab Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Sav"
+" F1/? Help • Ctrl+T Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save •"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_small_terminal.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_small_terminal.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 158
 expression: output
 ---
 "╭ Object ───────────────── L1-3/3 (0%) ╮"
@@ -10,5 +11,5 @@ expression: output
 "╰──────────────────────────────────────╯"
 "╭ Query [INSERT] ─ Ctrl+A AI Assistant ╮"
 "│                                      │"
-"╰ts • Ctrl+P Previous Query • Ctrl+N Ne╯"
+"╰ • Ctrl+P Previous Query • Ctrl+N Next╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Sear"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_wide_terminal.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_wide_terminal.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 167
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -30,5 +31,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                                                                      │"
-"╰────────────── Shift+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ───────────────╯"
+"╰──────────────── Ctrl+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ────────────────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+W Save • Ctrl+Q Output Quer"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_with_array_data.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_with_array_data.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 40
 expression: output
 ---
 "╭ Stream [3] ───────────────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.[].name                                                                      │"
-"╰─── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───╯"
+"╰──── Ctrl+T Navigate Results • Enter Output Result • Ctrl+Q Output Query ─────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_with_error.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_with_error.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 137
 expression: output
 ---
 "╭   ⚠ Syntax Error   Number | Showing last successful result ───── L1-1/1 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.foo                                                                          │"
-"╰─────────────── Shift+Tab Navigate Results • Ctrl+E Show Error ───────────────╯"
+"╰──────────────── Ctrl+T Navigate Results • Ctrl+E Show Error ─────────────────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_with_query.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__basic_ui_tests__snapshot_ui_with_query.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/basic_ui_tests.rs
+assertion_line: 28
 expression: output
 ---
 "╭ String ───────────────────────────────────────────────────────── L1-1/1 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
-"╰─── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───╯"
+"╰──── Ctrl+T Navigate Results • Enter Output Result • Ctrl+Q Output Query ─────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__error_handling_tests__snapshot_file_load_error_full_details_in_results_area.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__error_handling_tests__snapshot_file_load_error_full_details_in_results_area.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/error_handling_tests.rs
+assertion_line: 101
 expression: output
 ---
 "╭ Error ───────────────────────────────────────────────────────────────────────────────────────────────────────────────╮"
@@ -30,5 +31,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                                                                      │"
-"╰────────────── Shift+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ───────────────╯"
+"╰──────────────── Ctrl+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ────────────────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+W Save • Ctrl+Q Output Quer"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__error_handling_tests__snapshot_file_load_error_with_notification.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__error_handling_tests__snapshot_file_load_error_with_notification.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/error_handling_tests.rs
+assertion_line: 78
 expression: output
 ---
 "╭ Error ───────────────────────────────────────────────────────────────────────╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_autocomplete_popup_mixed_types.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_autocomplete_popup_mixed_types.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 150
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰─╰────────────────────────╯───────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_autocomplete_popup_selected_item_with_signature.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_autocomplete_popup_selected_item_with_signature.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 128
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰─╰───────────────────────────╯────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_autocomplete_popup_with_function_signatures.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_autocomplete_popup_with_function_signatures.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 100
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰─╰────────────────────────────╯───────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_help_popup.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_help_popup.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 61
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -15,14 +16,14 @@ expression: output
 "│    │     Enter          Output filtered JSON and exit                   █    │"
 "│    │     Ctrl+Q         Output query string only and exit               █    │"
 "│    │     Shift+Tab      Switch focus (Input / Results)                  █    │"
-"│    │     Ctrl+Y         Copy focused pane (query or results)            █    │"
-"│    │     Ctrl+O         Copy results from any focus                     █    │"
-"│    │     Ctrl+W         Save result to file                             █    │"
+"│    │     Ctrl+T         Switch focus (Input / Results)                  █    │"
+"│    │     Ctrl+I         Toggle function tooltip                         ║    │"
+"│    │     Ctrl+Y         Copy focused pane (query or results)            ║    │"
+"│    │     Ctrl+O         Copy results from any focus                     ║    │"
+"│    │     Ctrl+W         Save result to file                             ║    │"
 "│    │     q              Quit (in Normal mode or Results pane)           ║    │"
-"│    │     Ctrl+E         Toggle error overlay                            ║    │"
-"│    │                                                                    ║    │"
-"╰────│     ── PASTE RECOVERY (no input on launch) ──                      ║────╯"
+"╰────│     Ctrl+E         Toggle error overlay                            ║────╯"
 "╭ Que│                                                                    ║ant ╮"
 "│    ╰───── 1-7 Jump • Tab Next • h/l Switch • j/k Scroll • q Close ──────╯    │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_help_popup_with_ai_tab.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_help_popup_with_ai_tab.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 74
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰────│                                                                    │────╯"
 "╭ Que│                                                                    │ant ╮"
 "│    ╰───── 1-7 Jump • Tab Next • h/l Switch • j/k Scroll • q Close ──────╯    │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 23
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup_no_matches.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup_no_matches.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 51
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup_scrolled_bottom.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup_scrolled_bottom.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 350
 expression: output
 ---
 "╭ History (20/20) ─────────────────────────────────────────────────────────────╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup_scrolled_middle.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup_scrolled_middle.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 333
 expression: output
 ---
 "╭ History (20/20) ─────────────────────────────────────────────────────────────╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup_with_search.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_history_popup_with_search.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 38
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_hint_disabled_on_function.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_hint_disabled_on_function.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 235
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -22,7 +23,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"
-"╭ Query [INSERT] ──────────────────────── Ctrl+T Tooltip • Ctrl+A AI Assistant ╮"
+"╭ Query [INSERT] ──────────────────────── Ctrl+I Tooltip • Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_no_ai_hint_when_ai_visible.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_no_ai_hint_when_ai_visible.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 285
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────╰──────────── Ctrl+A Close ────────────╯╯"
 "╭ Query [INSERT] ──────────────────────────────────────────────────────────────╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_no_hint_disabled_no_function.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_no_hint_disabled_no_function.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 259
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_no_hint_enabled.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_no_hint_enabled.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 247
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -21,8 +22,8 @@ expression: output
 "│                 │                                                          │ │"
 "│                 │ 💡 For null-safe checks, use select(.field? // false)    │ │" Hidden by multi-width symbols: [(21, " ")]
 "│                 │                                                          │ │"
-"╰─────────────────╰───────────────────── Ctrl+T Dismiss ─────────────────────╯─╯"
+"╰─────────────────╰───────────────────── Ctrl+I Dismiss ─────────────────────╯─╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_with_ai_hint.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_border_with_ai_hint.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 272
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_both_hints_when_tooltip_available.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_both_hints_when_tooltip_available.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 364
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -22,7 +23,7 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"
-"╭ Query [INSERT] ──────────────────────── Ctrl+T Tooltip • Ctrl+A AI Assistant ╮"
+"╭ Query [INSERT] ──────────────────────── Ctrl+I Tooltip • Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_no_hints_when_ai_visible.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_no_hints_when_ai_visible.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 398
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────╰──────────── Ctrl+A Close ────────────╯╯"
 "╭ Query [INSERT] ──────────────────────────────────────────────────────────────╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_only_ai_hint_when_tooltip_active.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_input_only_ai_hint_when_tooltip_active.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 381
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -21,8 +22,8 @@ expression: output
 "│                 │                                                          │ │"
 "│                 │ 💡 For null-safe checks, use select(.field? // false)    │ │" Hidden by multi-width symbols: [(21, " ")]
 "│                 │                                                          │ │"
-"╰─────────────────╰───────────────────── Ctrl+T Dismiss ─────────────────────╯─╯"
+"╰─────────────────╰───────────────────── Ctrl+I Dismiss ─────────────────────╯─╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
-"╰t+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hi╯"
+"╰l+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R Hist╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_and_autocomplete_both_visible.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_and_autocomplete_both_visible.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 314
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -27,8 +28,8 @@ expression: output
 "│ │  select(expr)  [function]  │                                │ 💡 Use [.[] | expr] for same result - less memory  │ │" Hidden by multi-width symbols: [(67, " ")]
 "│ │  sort          [function]  │                                │    for large arrays                                │ │"
 "│ │  sort_by(expr) [function]  │                                │                                                    │ │"
-"╰─╰────────────────────────────╯────────────────────────────────╰────────────────── Ctrl+T Dismiss ──────────────────╯─╯"
+"╰─╰────────────────────────────╯────────────────────────────────╰────────────────── Ctrl+I Dismiss ──────────────────╯─╯"
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                                                                      │"
-"╰────────────── Shift+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ───────────────╯"
+"╰──────────────── Ctrl+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ────────────────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+W Save • Ctrl+Q Output Quer"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_dismiss_hint.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_dismiss_hint.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 199
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -27,8 +28,8 @@ expression: output
 "│                                                            │ 💡 Use sort_by(-.field) instead of sort_by(.field) |  │ │" Hidden by multi-width symbols: [(64, " ")]
 "│                                                            │    reverse                                            │ │"
 "│                                                            │                                                       │ │"
-"╰────────────────────────────────────────────────────────────╰─────────────────── Ctrl+T Dismiss ────────────────────╯─╯"
+"╰────────────────────────────────────────────────────────────╰─────────────────── Ctrl+I Dismiss ────────────────────╯─╯"
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                                                                      │"
-"╰────────────── Shift+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ───────────────╯"
+"╰──────────────── Ctrl+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ────────────────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+W Save • Ctrl+Q Output Quer"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_operator_alternative.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_operator_alternative.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 211
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -27,8 +28,8 @@ expression: output
 "│                                             │ 💡 Only triggers on null/false - use 'if . == "" then ... end' for   │ │" Hidden by multi-width symbols: [(49, " ")]
 "│                                             │    empty strings                                                     │ │"
 "│                                             │                                                                      │ │"
-"╰─────────────────────────────────────────────╰─────────────────────────── Ctrl+T Dismiss ───────────────────────────╯─╯"
+"╰─────────────────────────────────────────────╰─────────────────────────── Ctrl+I Dismiss ───────────────────────────╯─╯"
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                                                                      │"
-"╰────────────── Shift+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ───────────────╯"
+"╰──────────────── Ctrl+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ────────────────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+W Save • Ctrl+Q Output Quer"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_operator_update.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_operator_update.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 223
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -27,8 +28,8 @@ expression: output
 "│                                                    │ 💡 Right side receives current value as input; use = for      │ │" Hidden by multi-width symbols: [(56, " ")]
 "│                                                    │    simple assignment                                          │ │"
 "│                                                    │                                                               │ │"
-"╰────────────────────────────────────────────────────╰─────────────────────── Ctrl+T Dismiss ────────────────────────╯─╯"
+"╰────────────────────────────────────────────────────╰─────────────────────── Ctrl+I Dismiss ────────────────────────╯─╯"
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                                                                      │"
-"╰────────────── Shift+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ───────────────╯"
+"╰──────────────── Ctrl+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ────────────────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+W Save • Ctrl+Q Output Quer"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_popup_positioning.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_popup_positioning.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 186
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -27,8 +28,8 @@ expression: output
 "│                                                               │ 💡 Use [.[] | expr] for same result - less memory  │ │" Hidden by multi-width symbols: [(67, " ")]
 "│                                                               │    for large arrays                                │ │"
 "│                                                               │                                                    │ │"
-"╰───────────────────────────────────────────────────────────────╰────────────────── Ctrl+T Dismiss ──────────────────╯─╯"
+"╰───────────────────────────────────────────────────────────────╰────────────────── Ctrl+I Dismiss ──────────────────╯─╯"
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                                                                      │"
-"╰────────────── Shift+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ───────────────╯"
+"╰──────────────── Ctrl+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ────────────────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+W Save • Ctrl+Q Output Quer"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_popup_with_all_fields.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_popup_with_all_fields.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 162
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -27,8 +28,8 @@ expression: output
 "│                                                     │                                                              │ │"
 "│                                                     │ 💡 For null-safe checks, use select(.field? // false)        │ │" Hidden by multi-width symbols: [(57, " ")]
 "│                                                     │                                                              │ │"
-"╰─────────────────────────────────────────────────────╰─────────────────────── Ctrl+T Dismiss ───────────────────────╯─╯"
+"╰─────────────────────────────────────────────────────╰─────────────────────── Ctrl+I Dismiss ───────────────────────╯─╯"
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                                                                      │"
-"╰────────────── Shift+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ───────────────╯"
+"╰──────────────── Ctrl+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ────────────────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+W Save • Ctrl+Q Output Quer"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_popup_without_tip.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__popup_tests__snapshot_tooltip_popup_without_tip.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/popup_tests.rs
+assertion_line: 174
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -27,8 +28,8 @@ expression: output
 "│                                                      │ 💡 For pattern matching: with_entries(select(.key |         │ │" Hidden by multi-width symbols: [(58, " ")]
 "│                                                      │    test("x") | not))                                        │ │"
 "│                                                      │                                                             │ │"
-"╰──────────────────────────────────────────────────────╰────────────────────── Ctrl+T Dismiss ───────────────────────╯─╯"
+"╰──────────────────────────────────────────────────────╰────────────────────── Ctrl+I Dismiss ───────────────────────╯─╯"
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                                                                      │"
-"╰────────────── Shift+Tab Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ───────────────╯"
+"╰──────────────── Ctrl+T Navigate Results • Ctrl+P Previous Query • Ctrl+N Next Query • Ctrl+R History ────────────────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+W Save • Ctrl+Q Output Quer"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_query_spinner_frame_0.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_query_spinner_frame_0.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/processing_tests.rs
+assertion_line: 21
 expression: output
 ---
 "╭⠋ Object ──────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
-"╰─── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───╯"
+"╰──── Ctrl+T Navigate Results • Enter Output Result • Ctrl+Q Output Query ─────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_query_spinner_frame_64.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_query_spinner_frame_64.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/processing_tests.rs
+assertion_line: 53
 expression: output
 ---
 "╭⠇ Object ──────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
-"╰─── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───╯"
+"╰──── Ctrl+T Navigate Results • Enter Output Result • Ctrl+Q Output Query ─────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_query_spinner_frame_8.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_query_spinner_frame_8.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/processing_tests.rs
+assertion_line: 37
 expression: output
 ---
 "╭⠙ Object ──────────────────────────────────────────────────────── L1-4/4 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
-"╰─── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───╯"
+"╰──── Ctrl+T Navigate Results • Enter Output Result • Ctrl+Q Output Query ─────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_with_previous_result.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_with_previous_result.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/processing_tests.rs
+assertion_line: 74
 expression: output
 ---
 "╭⠹ String ──────────────────────────────────────────────────────── L1-1/1 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.age                                                                          │"
-"╰─── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───╯"
+"╰──── Ctrl+T Navigate Results • Enter Output Result • Ctrl+Q Output Query ─────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_with_syntax_error.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__processing_tests__snapshot_processing_with_syntax_error.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/processing_tests.rs
+assertion_line: 97
 expression: output
 ---
 "╭⠸    ⚠ Syntax Error   String | Showing last successful result ─── L1-1/1 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid[                                                                     │"
-"╰─────────────── Shift+Tab Navigate Results • Ctrl+E Show Error ───────────────╯"
+"╰──────────────── Ctrl+T Navigate Results • Ctrl+E Show Error ─────────────────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_empty_focused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_empty_focused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/result_state_tests.rs
+assertion_line: 51
 expression: output
 ---
 "╭   ∅ No Results   Array [2 objects] | Showing last non-empty result ───────────────────────────────────── L1-8/8 (0%) ╮"
@@ -27,8 +28,8 @@ expression: output
 "│                                                                                                                      │"
 "│                                                                                                                      │"
 "│                                                                                                                      │"
-"╰─────────────── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ siblings ───────────────╯"
+"╰───────────── Ctrl+T Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ siblings ──────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.[] | select(.name == "nonexistent")                                                                                  │"
 "╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
-" F1/? Help • Shift+Tab Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save • Ctrl+C Quit                         "
+" F1/? Help • Ctrl+T Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save • Ctrl+C Quit                            "

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_empty_unfocused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_empty_unfocused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/result_state_tests.rs
+assertion_line: 70
 expression: output
 ---
 "╭   ∅ No Results   Array [2 objects] | Showing last non-empty result ───────────────────────────────────── L1-8/8 (0%) ╮"
@@ -30,5 +31,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.[] | select(.name == "nonexistent")                                                                                  │"
-"╰─────────────────────── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───────────────────────╯"
+"╰──────────────────────── Ctrl+T Navigate Results • Enter Output Result • Ctrl+Q Output Query ─────────────────────────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+W Save • Ctrl+Q Output Quer"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_error_focused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_error_focused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/result_state_tests.rs
+assertion_line: 84
 expression: output
 ---
 "╭   ⚠ Syntax Error   Object | Showing last successful result ───────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -27,8 +28,8 @@ expression: output
 "│                                                                                                                      │"
 "│                                                                                                                      │"
 "│                                                                                                                      │"
-"╰─────────────── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ siblings ───────────────╯"
+"╰───────────── Ctrl+T Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ siblings ──────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid syntax here                                                                                                  │"
 "╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
-" F1/? Help • Shift+Tab Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save • Ctrl+C Quit                         "
+" F1/? Help • Ctrl+T Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save • Ctrl+C Quit                            "

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_error_unfocused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_error_unfocused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/result_state_tests.rs
+assertion_line: 98
 expression: output
 ---
 "╭   ⚠ Syntax Error   Object | Showing last successful result ───────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -30,5 +31,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid syntax here                                                                                                  │"
-"╰─────────────────────────────────── Shift+Tab Navigate Results • Ctrl+E Show Error ───────────────────────────────────╯"
+"╰──────────────────────────────────── Ctrl+T Navigate Results • Ctrl+E Show Error ─────────────────────────────────────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+W Save • Ctrl+Q Output Quer"

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_success_focused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_success_focused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/result_state_tests.rs
+assertion_line: 19
 expression: output
 ---
 "╭ Stream [3]  · . ──────────────────────────────────────────────────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -27,8 +28,8 @@ expression: output
 "│                                                                                                                      │"
 "│                                                                                                                      │"
 "│                                                                                                                      │"
-"╰─────────────── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ siblings ───────────────╯"
+"╰───────────── Ctrl+T Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap • ]/[ siblings ──────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.[].name                                                                                                              │"
 "╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
-" F1/? Help • Shift+Tab Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save • Ctrl+C Quit                         "
+" F1/? Help • Ctrl+T Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save • Ctrl+C Quit                            "

--- a/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_success_unfocused.snap
+++ b/src/app/app_render_tests/snapshots/jiq__app__app_render_tests__result_state_tests__snapshot_results_success_unfocused.snap
@@ -1,5 +1,6 @@
 ---
 source: src/app/app_render_tests/result_state_tests.rs
+assertion_line: 32
 expression: output
 ---
 "╭ Stream [3] ───────────────────────────────────────────────────────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -30,5 +31,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────────────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.[].name                                                                                                              │"
-"╰─────────────────────── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───────────────────────╯"
+"╰──────────────────────── Ctrl+T Navigate Results • Enter Output Result • Ctrl+Q Output Query ─────────────────────────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy Result • Ctrl+W Save • Ctrl+Q Output Quer"

--- a/src/help/help_content.rs
+++ b/src/help/help_content.rs
@@ -25,6 +25,8 @@ pub const HELP_CATEGORIES: &[HelpCategory] = &[
                     ("Enter", "Output filtered JSON and exit"),
                     ("Ctrl+Q", "Output query string only and exit"),
                     ("Shift+Tab", "Switch focus (Input / Results)"),
+                    ("Ctrl+T", "Switch focus (Input / Results)"),
+                    ("Ctrl+I", "Toggle function tooltip"),
                     ("Ctrl+Y", "Copy focused pane (query or results)"),
                     ("Ctrl+O", "Copy results from any focus"),
                     ("Ctrl+W", "Save result to file"),

--- a/src/help/help_line_render.rs
+++ b/src/help/help_line_render.rs
@@ -30,7 +30,7 @@ fn get_context_hints(app: &App) -> Vec<(&'static str, &'static str)> {
     } else if app.focus == Focus::InputField && app.input.editor_mode == EditorMode::Insert {
         hints!["F1" => "Help", "Ctrl+S" => "Snippets", "Ctrl+F" => "Search", "Enter" => "Output Result", "Ctrl+O" => "Copy Result", "Ctrl+W" => "Save", "Ctrl+Q" => "Output Query", "Ctrl+C" => "Quit"]
     } else if app.focus == Focus::ResultsPane {
-        hints!["F1/?" => "Help", "Shift+Tab" => "Edit Query", "Ctrl+S" => "Snippets", "Ctrl+F" => "Search", "Ctrl+W" => "Save", "Ctrl+C" => "Quit"]
+        hints!["F1/?" => "Help", "Ctrl+T" => "Edit Query", "Ctrl+S" => "Snippets", "Ctrl+F" => "Search", "Ctrl+W" => "Save", "Ctrl+C" => "Quit"]
     } else {
         hints!["F1/?" => "Help", "Ctrl+S" => "Snippets", "Ctrl+F" => "Search", "Enter" => "Output Result", "Ctrl+O" => "Copy Result", "Ctrl+W" => "Save", "Ctrl+Q" => "Output Query", "Ctrl+C" => "Quit"]
     }

--- a/src/help/snapshots/jiq__help__help_line_render__help_line_render_tests__snapshot_help_line_results_pane.snap
+++ b/src/help/snapshots/jiq__help__help_line_render__help_line_render_tests__snapshot_help_line_results_pane.snap
@@ -1,5 +1,6 @@
 ---
 source: src/help/help_line_render_tests.rs
+assertion_line: 68
 expression: output
 ---
-" F1/? Help • Shift+Tab Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save • Ctrl+C Quit                         "
+" F1/? Help • Ctrl+T Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save • Ctrl+C Quit                            "

--- a/src/input/input_render.rs
+++ b/src/input/input_render.rs
@@ -90,7 +90,7 @@ pub fn render_field(app: &mut App, frame: &mut Frame, area: Rect) -> Rect {
     } else if has_tooltip_available {
         // Neither active, tooltip available: show both hints
         let combined = theme::border_hints::build_hints(
-            &[("Ctrl+T", "Tooltip"), ("Ctrl+A", "AI Assistant")],
+            &[("Ctrl+I", "Tooltip"), ("Ctrl+A", "AI Assistant")],
             border_color,
         );
         block = block.title_top(combined.alignment(Alignment::Right));
@@ -104,7 +104,7 @@ pub fn render_field(app: &mut App, frame: &mut Frame, area: Rect) -> Rect {
         if has_error {
             block = block.title_bottom(
                 theme::border_hints::build_hints(
-                    &[("Shift+Tab", "Navigate Results"), ("Ctrl+E", "Show Error")],
+                    &[("Ctrl+T", "Navigate Results"), ("Ctrl+E", "Show Error")],
                     theme::input::border_error(),
                 )
                 .alignment(Alignment::Center),
@@ -113,7 +113,7 @@ pub fn render_field(app: &mut App, frame: &mut Frame, area: Rect) -> Rect {
             block = block.title_bottom(
                 theme::border_hints::build_hints(
                     &[
-                        ("Shift+Tab", "Navigate Results"),
+                        ("Ctrl+T", "Navigate Results"),
                         ("Enter", "Output Result"),
                         ("Ctrl+Q", "Output Query"),
                     ],
@@ -125,7 +125,7 @@ pub fn render_field(app: &mut App, frame: &mut Frame, area: Rect) -> Rect {
             block = block.title_bottom(
                 theme::border_hints::build_hints(
                     &[
-                        ("Shift+Tab", "Navigate Results"),
+                        ("Ctrl+T", "Navigate Results"),
                         ("Ctrl+P", "Previous Query"),
                         ("Ctrl+N", "Next Query"),
                         ("Ctrl+R", "History"),

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_focused_insert_mode.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_focused_insert_mode.snap
@@ -1,5 +1,6 @@
 ---
 source: src/input/input_render_tests.rs
+assertion_line: 28
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-1/1 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
-"╰─── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───╯"
+"╰──── Ctrl+T Navigate Results • Enter Output Result • Ctrl+Q Output Query ─────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_focused_normal_mode.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_focused_normal_mode.snap
@@ -1,5 +1,6 @@
 ---
 source: src/input/input_render_tests.rs
+assertion_line: 41
 expression: output
 ---
 "╭ Object ───────────────────────────────────────────────────────── L1-1/1 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [NORMAL] (press 'i' to edit) ───────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
-"╰─── Shift+Tab Navigate Results • Enter Output Result • Ctrl+Q Output Query ───╯"
+"╰──── Ctrl+T Navigate Results • Enter Output Result • Ctrl+Q Output Query ─────╯"
 " F1/? Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy"

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_focused_with_syntax_error.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_focused_with_syntax_error.snap
@@ -1,5 +1,6 @@
 ---
 source: src/input/input_render_tests.rs
+assertion_line: 119
 expression: output
 ---
 "╭   ⚠ Syntax Error   Object | Showing last successful result ───── L1-3/3 (0%) ╮"
@@ -24,5 +25,5 @@ expression: output
 "╰──────────────────────────────────────────────────────────────────────────────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid[                                                                     │"
-"╰─────────────── Shift+Tab Navigate Results • Ctrl+E Show Error ───────────────╯"
+"╰──────────────── Ctrl+T Navigate Results • Ctrl+E Show Error ─────────────────╯"
 " F1 Help • Ctrl+S Snippets • Ctrl+F Search • Enter Output Result • Ctrl+O Copy R"

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_empty.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_empty.snap
@@ -1,5 +1,6 @@
 ---
 source: src/input/input_render_tests.rs
+assertion_line: 77
 expression: output
 ---
 "╭ Object  · . ──────────────────────────────────────────────────── L1-3/3 (0%) ╮"
@@ -21,8 +22,8 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰───── Ctrl+T Edit Query • i Edit Query • > value • * iterate • ^ parent ──────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│                                                                              │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"
-" F1/? Help • Shift+Tab Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Sav"
+" F1/? Help • Ctrl+T Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save •"

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_insert_mode.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_insert_mode.snap
@@ -1,5 +1,6 @@
 ---
 source: src/input/input_render_tests.rs
+assertion_line: 54
 expression: output
 ---
 "╭ Object  · . ──────────────────────────────────────────────────── L1-1/1 (0%) ╮"
@@ -21,8 +22,8 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰───── Ctrl+T Edit Query • i Edit Query • > value • * iterate • ^ parent ──────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"
-" F1/? Help • Shift+Tab Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Sav"
+" F1/? Help • Ctrl+T Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save •"

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_long_query.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_long_query.snap
@@ -1,5 +1,6 @@
 ---
 source: src/input/input_render_tests.rs
+assertion_line: 94
 expression: output
 ---
 "╭ Object  · . ──────────────────────────────────────────────────── L1-1/1 (0%) ╮"
@@ -21,8 +22,8 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰───── Ctrl+T Edit Query • i Edit Query • > value • * iterate • ^ parent ──────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.users | map(select(.name == "Alice")) | .[0].name                            │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"
-" F1/? Help • Shift+Tab Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Sav"
+" F1/? Help • Ctrl+T Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save •"

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_normal_mode.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_normal_mode.snap
@@ -1,5 +1,6 @@
 ---
 source: src/input/input_render_tests.rs
+assertion_line: 67
 expression: output
 ---
 "╭ Object  · . ──────────────────────────────────────────────────── L1-1/1 (0%) ╮"
@@ -21,8 +22,8 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰───── Ctrl+T Edit Query • i Edit Query • > value • * iterate • ^ parent ──────╯"
 "╭ Query [NORMAL] (press 'i' to edit) ───────────────────── Ctrl+A AI Assistant ╮"
 "│.name                                                                         │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"
-" F1/? Help • Shift+Tab Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Sav"
+" F1/? Help • Ctrl+T Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save •"

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_normal_mode_with_syntax_error.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_normal_mode_with_syntax_error.snap
@@ -1,5 +1,6 @@
 ---
 source: src/input/input_render_tests.rs
+assertion_line: 147
 expression: output
 ---
 "╭   ⚠ Syntax Error   Object | Showing last successful result ───── L1-3/3 (0%) ╮"
@@ -21,8 +22,8 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰───── Ctrl+T Edit Query • i Edit Query • > value • * iterate • ^ parent ──────╯"
 "╭ Query [NORMAL] (press 'i' to edit) ───────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid[                                                                     │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"
-" F1/? Help • Shift+Tab Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Sav"
+" F1/? Help • Ctrl+T Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save •"

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_with_syntax_error.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_with_syntax_error.snap
@@ -1,5 +1,6 @@
 ---
 source: src/input/input_render_tests.rs
+assertion_line: 106
 expression: output
 ---
 "╭   ⚠ Syntax Error   Object | Showing last successful result ───── L1-3/3 (0%) ╮"
@@ -21,8 +22,8 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰───── Ctrl+T Edit Query • i Edit Query • > value • * iterate • ^ parent ──────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid[                                                                     │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"
-" F1/? Help • Shift+Tab Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Sav"
+" F1/? Help • Ctrl+T Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save •"

--- a/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_with_syntax_error_mode_text_red.snap
+++ b/src/input/snapshots/jiq__input__input_render_tests__snapshot_query_unfocused_with_syntax_error_mode_text_red.snap
@@ -1,5 +1,6 @@
 ---
 source: src/input/input_render_tests.rs
+assertion_line: 133
 expression: output
 ---
 "╭   ⚠ Syntax Error   Object | Showing last successful result ───── L1-3/3 (0%) ╮"
@@ -21,8 +22,8 @@ expression: output
 "│                                                                              │"
 "│                                                                              │"
 "│                                                                              │"
-"╰── Tab Edit Query • i Edit Query • > value • * iterate • ^ parent • } wrap ───╯"
+"╰───── Ctrl+T Edit Query • i Edit Query • > value • * iterate • ^ parent ──────╯"
 "╭ Query [INSERT] ───────────────────────────────────────── Ctrl+A AI Assistant ╮"
 "│.invalid[                                                                     │"
 "╰──────────────────────────────────────────────────────────────────────────────╯"
-" F1/? Help • Shift+Tab Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Sav"
+" F1/? Help • Ctrl+T Edit Query • Ctrl+S Snippets • Ctrl+F Search • Ctrl+W Save •"

--- a/src/results/results_render.rs
+++ b/src/results/results_render.rs
@@ -56,7 +56,7 @@ fn path_chord_hints(can_undo: bool) -> Vec<(&'static str, &'static str)> {
 
 fn build_results_pane_hints(can_undo: bool) -> Line<'static> {
     let mut hints: Vec<(&'static str, &'static str)> =
-        vec![("Tab", "Edit Query"), ("i", "Edit Query")];
+        vec![("Ctrl+T", "Edit Query"), ("i", "Edit Query")];
     hints.extend(path_chord_hints(can_undo));
     theme::border_hints::build_hints(&hints, theme::results::hint_key())
 }

--- a/src/tooltip/tooltip_render.rs
+++ b/src/tooltip/tooltip_render.rs
@@ -222,7 +222,7 @@ pub fn render_popup(app: &App, frame: &mut Frame, input_area: Rect) -> Option<Re
 
     // Build dismiss hint for bottom-center of border
     let dismiss_hint =
-        theme::border_hints::build_hints(&[("Ctrl+T", "Dismiss")], theme::tooltip::border());
+        theme::border_hints::build_hints(&[("Ctrl+I", "Dismiss")], theme::tooltip::border());
 
     // Create the popup widget with purple border
     // Title on top-left, dismiss hint on bottom-center, padding inside


### PR DESCRIPTION
## Summary
- Tooltip toggle moves from `Ctrl+T` to `Ctrl+I` (mnemonic: "info").
- `Ctrl+T` now toggles focus between the query input and the results pane, joining `Shift+Tab`. It also closes the history popup when switching, mirroring `Shift+Tab`.
- Bottom-border focus hint now advertises `Ctrl+T` and is context-aware: `Ctrl+T Navigate Results` when the query input is focused, `Ctrl+T Edit Query` when the results pane is focused (global help-line strip updated to match).
- `Shift+Tab` and `Tab`/`i` still work as before; only the promoted on-screen hint changed.
- Updated input border hint, tooltip dismiss hint, F1 help window, README, CHANGELOG, and docs (`quick-reference`, `features/tooltip`, `configuration`). Snapshots regenerated.

## Test plan
- [x] cargo test (full suite, 7,640 tests)
- [x] cargo build --release (zero warnings)
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo fmt --all --check
- [x] Manual TUI validation